### PR TITLE
Remove useless global.json

### DIFF
--- a/NTumbleBit.sln
+++ b/NTumbleBit.sln
@@ -5,11 +5,6 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8E0926EA-6EC7-4757-9A9D-5A9E8558295B}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8DCE4E4C-5174-491F-88BD-B561A44DE3EB}"
-	ProjectSection(SolutionItems) = preProject
-		global.json = global.json
-	EndProjectSection
-EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NTumbleBit", "NTumbleBit\NTumbleBit.xproj", "{094AECD5-E0D8-43A9-A0BD-39B01F51A1F2}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NTumbleBit.Tests", "NTumbleBit.Tests\NTumbleBit.Tests.xproj", "{800A5906-C050-4E75-9D7C-0CB1C404A0F8}"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-﻿{
-  "projects": [ "src", "test" ],
-  "sdk": {
-    "version": "1.0.0-preview2-003131"
-  }
-}


### PR DESCRIPTION
Remove global.json:

Its content was:  
```
{		
  "projects": [ "src", "test" ],		
  "sdk": {		
    "version": "1.0.0-preview2-003131"		
  }		
}
```

We don't organize our projects into src, test, etc folders.  
I have chosen this, because the new csproj structure doesn't do it either AND I wanted to keep a clean commit history, so the changes could be seen nicely when I ported .net core.  

The sdk part is useless, too:  if omitted the tooling simply assumes the latest SDK installed.  
  
https://docs.microsoft.com/en-us/dotnet/articles/core/tools/global-json  
https://ievangelist.github.io/blog/the-global-json/