### PR TITLE
WIP: Tor integration (testing needed)

### DIFF
--- a/NTumbleBit.CLI/Program.cs
+++ b/NTumbleBit.CLI/Program.cs
@@ -68,6 +68,7 @@ namespace NTumbleBit.CLI
 					}
 
 					TumblerClient client;
+					TorParameters torParameters = null;
 					bool? useTor = config.GetOrDefault("tor.use", null as bool?);
 					if(useTor == null) throw new ConfigException("tor.use is not configured correctly");
 					else if((bool)useTor)
@@ -84,7 +85,7 @@ namespace NTumbleBit.CLI
 						}
 						else
 						{
-							TorParameters torParameters = new TorParameters();
+							torParameters = new TorParameters();
 							string TorHost = config.GetOrDefault("tor.host", null as string);
 							int? TorSocksPort = config.GetOrDefault("tor.socksport", null as int?);
 							int? TorControlPort = config.GetOrDefault("tor.controlport", null as int?);
@@ -153,7 +154,7 @@ namespace NTumbleBit.CLI
 					}
 					var destinationWallet = new ClientDestinationWallet("", pubKey, keypath, dbreeze);
 					var stateMachine = new StateMachinesExecutor(parameters, client, destinationWallet, services, dbreeze, logger);
-					stateMachine.Start(source.Token);
+					stateMachine.Start(source.Token, torParameters);
 					Logs.Configuration.LogInformation("State machines started");
 				}
 				Logs.Configuration.LogInformation("Press enter to stop");

--- a/NTumbleBit.CLI/Program.cs
+++ b/NTumbleBit.CLI/Program.cs
@@ -167,7 +167,7 @@ namespace NTumbleBit.CLI
 			}
 			catch (Exception ex)
 			{
-				if(ex is TorException || (ex is AggregateException && ex.InnerException is TorException))
+				if(ex is TorException || (ex is AggregateException && ((AggregateException)ex).InnerExceptions.Any(x => x is TorException)))
 				{
 					Logs.Configuration.LogError("You are not running Tor or not configured it correctly" + Environment.NewLine +
 					   $"Details: {ex.Message}");

--- a/NTumbleBit.CLI/Program.cs
+++ b/NTumbleBit.CLI/Program.cs
@@ -74,8 +74,9 @@ namespace NTumbleBit.CLI
 					{
 						// If the server is on the same machine TOR would refuse the connection, so don't even try
 						if(server.DnsSafeHost.Equals("10.0.2.2", StringComparison.Ordinal) || // VM host
-							server.DnsSafeHost.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
-							server.DnsSafeHost.Equals("127.0.0.1", StringComparison.Ordinal)) // localhost
+							server.DnsSafeHost.Equals("localhost", StringComparison.OrdinalIgnoreCase) || // localhost
+							server.DnsSafeHost.Equals("127.0.0.1", StringComparison.Ordinal) || // localhost
+							server.DnsSafeHost.Equals("0.0.0.0", StringComparison.Ordinal)) // localhost
 						{
 							Logs.Configuration.LogInformation("Not using TOR. Reason: The server is running on the same machine.");
 							useTor = false;

--- a/NTumbleBit.CLI/Program.cs
+++ b/NTumbleBit.CLI/Program.cs
@@ -12,7 +12,9 @@ using NTumbleBit.Client.Tumbler;
 using System.Threading;
 using NTumbleBit.Common.Logging;
 using System.Text;
+using DotNetTor;
 using NBitcoin.RPC;
+using NTumbleBit.Client;
 
 namespace NTumbleBit.CLI
 {
@@ -64,7 +66,45 @@ namespace NTumbleBit.CLI
 						Logs.Main.LogError("tumbler.server not configured");
 						throw new ConfigException();
 					}
-					var client = new TumblerClient(network, server);
+
+					TumblerClient client;
+					bool? useTor = config.GetOrDefault("tor.use", null as bool?);
+					if(useTor == null) throw new ConfigException("tor.use is not configured correctly");
+					else if((bool)useTor)
+					{
+						// If the server is on the same machine TOR would refuse the connection, so don't even try
+						if(server.DnsSafeHost.Equals("10.0.2.2", StringComparison.Ordinal) || // VM host
+							server.DnsSafeHost.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+							server.DnsSafeHost.Equals("127.0.0.1", StringComparison.Ordinal)) // localhost
+						{
+							Logs.Configuration.LogInformation("Not using TOR. Reason: The server is running on the same machine.");
+							useTor = false;
+							client = new TumblerClient(network, server);
+						}
+						else
+						{
+							TorParameters torParameters = new TorParameters();
+							string TorHost = config.GetOrDefault("tor.host", null as string);
+							int? TorSocksPort = config.GetOrDefault("tor.socksport", null as int?);
+							int? TorControlPort = config.GetOrDefault("tor.controlport", null as int?);
+							string TorControlPortPassword = config.GetOrDefault("tor.controlportpassword", null as string);
+							if(TorHost == null || TorSocksPort == null || TorControlPort == null || TorControlPortPassword == null)
+								throw new ConfigException("TOR is not configured correctly in your config file.");
+							else
+							{
+								torParameters.Host = TorHost;
+								torParameters.SocksPort = (int) TorSocksPort;
+								torParameters.ControlPort = (int) TorControlPort;
+								torParameters.ControlPortPassword = TorControlPortPassword;
+							}
+							client = new TumblerClient(network, server, torParameters);
+						}
+					}
+					else
+					{
+						client = new TumblerClient(network, server);
+					}
+
 					Logs.Configuration.LogInformation("Downloading tumbler information of " + server.AbsoluteUri);
 					var parameters = Retry(3, () => client.GetTumblerParameters());
 					Logs.Configuration.LogInformation("Tumbler Server Connection successfull");
@@ -124,7 +164,12 @@ namespace NTumbleBit.CLI
 				if(!string.IsNullOrEmpty(ex.Message))
 					Logs.Configuration.LogError(ex.Message);
 			}
-			catch(Exception ex)
+			catch (AggregateException ex) when (ex.InnerException is TorException)
+			{
+				Logs.Configuration.LogError("Your TOR is not running or not configured correctly" + Environment.NewLine +
+					$"Details: {ex.InnerException.Message}");
+			}
+			catch (Exception ex)
 			{
 				Logs.Configuration.LogError(ex.Message);
 				Logs.Configuration.LogDebug(ex.StackTrace);
@@ -160,6 +205,11 @@ namespace NTumbleBit.CLI
 				builder.AppendLine("#rpc.user=bitcoinuser");
 				builder.AppendLine("#rpc.password=bitcoinpassword");
 				builder.AppendLine("#rpc.cookiefile=yourbitcoinfolder/.cookie");
+				builder.AppendLine("#tor.use=false");
+				builder.AppendLine("#tor.host=127.0.0.1");
+				builder.AppendLine("#tor.socksport=9050");
+				builder.AppendLine("#tor.controlport=9051");
+				builder.AppendLine("#tor.controlportpassword=ILoveBitcoin21");
 				File.WriteAllText(config, builder.ToString());
 			}
 			return config;

--- a/NTumbleBit.CLI/Program.cs
+++ b/NTumbleBit.CLI/Program.cs
@@ -78,7 +78,7 @@ namespace NTumbleBit.CLI
 							server.DnsSafeHost.Equals("127.0.0.1", StringComparison.Ordinal) || // localhost
 							server.DnsSafeHost.Equals("0.0.0.0", StringComparison.Ordinal)) // localhost
 						{
-							Logs.Configuration.LogInformation("Not using TOR. Reason: The server is running on the same machine.");
+							Logs.Configuration.LogInformation("Not using Tor. Reason: The server is running on the same machine.");
 							useTor = false;
 							client = new TumblerClient(network, server);
 						}
@@ -167,8 +167,14 @@ namespace NTumbleBit.CLI
 			}
 			catch (AggregateException ex) when (ex.InnerException is TorException)
 			{
-				Logs.Configuration.LogError("Your TOR is not running or not configured correctly" + Environment.NewLine +
+				Logs.Configuration.LogError("You are not running Tor or not configured it correctly" + Environment.NewLine +
 					$"Details: {ex.InnerException.Message}");
+				Logs.Configuration.LogDebug(ex.StackTrace);
+			}
+			catch (AggregateException ex)
+			{
+				Logs.Configuration.LogError(ex.InnerException.Message);
+				Logs.Configuration.LogDebug(ex.StackTrace);
 			}
 			catch (Exception ex)
 			{

--- a/NTumbleBit.CLI/Program.cs
+++ b/NTumbleBit.CLI/Program.cs
@@ -167,14 +167,17 @@ namespace NTumbleBit.CLI
 			}
 			catch (Exception ex)
 			{
-				if(ex is TorException || (ex is AggregateException && ((AggregateException)ex).InnerExceptions.Any(x => x is TorException)))
+				if(ex is TorException ||
+					(ex is AggregateException && ((AggregateException) ex).InnerExceptions.Any(x => x is TorException)))
 				{
 					Logs.Configuration.LogError("You are not running Tor or not configured it correctly" + Environment.NewLine +
-					   $"Details: {ex.Message}");
-					Logs.Configuration.LogDebug(ex.StackTrace);
+												$"Details: {ex.Message}");
 
 				}
-				Logs.Configuration.LogError(ex.Message);
+				else
+				{
+					Logs.Configuration.LogError(ex.Message);
+				}
 				Logs.Configuration.LogDebug(ex.StackTrace);
 			}
 		}

--- a/NTumbleBit.Client/TorParameters.cs
+++ b/NTumbleBit.Client/TorParameters.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NTumbleBit.Client
+{
+    public class TorParameters
+	{
+		public string Host { get; set; }
+		public int SocksPort { get; set; }
+		public int ControlPort { get; set; }
+		public string ControlPortPassword { get; set; }
+	}
+}

--- a/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
+++ b/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
@@ -176,7 +176,7 @@ namespace NTumbleBit.Client.Tumbler
 						var voucherResponse = BobClient.AskUnsignedVoucher();
 						//Client ensures he is in the same cycle as the tumbler (would fail if one tumbler or client's chain isn't sync)
 						var tumblerCycle = Parameters.CycleGenerator.GetCycle(voucherResponse.CycleStart);
-						Assert(tumblerCycle.Start == cycle.Start, "invalid-phase");
+						Assert(tumblerCycle.Start == cycle.Start, "Invalid phase. The Tumbler's or the Client's chain may not be fully synced yet.");
 						//Saving the voucher for later
 						StartCycle = cycle.Start;
 						ClientChannelNegotiation = new ClientChannelNegotiation(Parameters, cycle.Start);

--- a/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
+++ b/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
@@ -26,7 +26,6 @@ namespace NTumbleBit.Client.Tumbler
 			BobClient = client;
 			Services = services;
 			DestinationWallet = destinationWallet;
-			WhoAmI = TumbleBitIdentity.Alice;
 		}
 
 		public PaymentStateMachine(
@@ -49,7 +48,7 @@ namespace NTumbleBit.Client.Tumbler
 				SolverClientSession = new SolverClientSession(parameters.CreateSolverParamaters(), state.SolverClientState);
 		}
 
-		private TumbleBitIdentity WhoAmI
+		private static TumbleBitIdentity WhoAmI
 		{
 			get; set;
 		}

--- a/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
+++ b/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
@@ -166,8 +166,9 @@ namespace NTumbleBit.Client.Tumbler
 				case CyclePhase.Registration:
 					if (!WhoAmI.Equals(TumbleBitIdentity.Bob))
 					{
-						BobClient.ChangeIpIfTorAsync().Wait();
-						logger.LogInformation("Changing identity to Bob...");
+						WhoAmI = TumbleBitIdentity.Bob;
+						if(BobClient.ChangeIpIfTorAsync().Result)
+							logger.LogInformation("Changing identity to Bob...");
 					}
 					if (ClientChannelNegotiation == null)
 					{
@@ -186,8 +187,9 @@ namespace NTumbleBit.Client.Tumbler
 				case CyclePhase.ClientChannelEstablishment:
 					if (!WhoAmI.Equals(TumbleBitIdentity.Alice))
 					{
-						AliceClient.ChangeIpIfTorAsync().Wait();
-						logger.LogInformation("Changing identity to Alice...");
+						WhoAmI = TumbleBitIdentity.Alice;
+						if(AliceClient.ChangeIpIfTorAsync().Result)
+							logger.LogInformation("Changing identity to Alice...");
 					}
 					if (ClientChannelNegotiation.Status == TumblerClientSessionStates.WaitingTumblerClientTransactionKey)
 					{
@@ -236,8 +238,9 @@ namespace NTumbleBit.Client.Tumbler
 				case CyclePhase.TumblerChannelEstablishment:
 					if (!WhoAmI.Equals(TumbleBitIdentity.Bob))
 					{
-						BobClient.ChangeIpIfTorAsync().Wait();
-						logger.LogInformation("Changing identity to Bob...");
+						WhoAmI = TumbleBitIdentity.Bob;
+						if(BobClient.ChangeIpIfTorAsync().Result)
+							logger.LogInformation("Changing identity to Bob...");
 					}
 					if (ClientChannelNegotiation != null && ClientChannelNegotiation.Status == TumblerClientSessionStates.WaitingGenerateTumblerTransactionKey)
 					{
@@ -277,8 +280,9 @@ namespace NTumbleBit.Client.Tumbler
 						{
 							if (!WhoAmI.Equals(TumbleBitIdentity.Alice))
 							{
-								AliceClient.ChangeIpIfTorAsync().Wait();
-								logger.LogInformation("Changing identity to Alice...");
+								WhoAmI = TumbleBitIdentity.Alice;
+								if(AliceClient.ChangeIpIfTorAsync().Result)
+									logger.LogInformation("Changing identity to Alice...");
 							}
 							logger.LogInformation("Tumbler escrow confirmed " + tumblerTx.Transaction.GetHash());
 							feeRate = GetFeeRate();

--- a/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
+++ b/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
@@ -2,13 +2,10 @@
 using NTumbleBit.Client.Tumbler.Services;
 using NTumbleBit.PuzzleSolver;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using NBitcoin;
 using NTumbleBit.PuzzlePromise;
 using Microsoft.Extensions.Logging;
-using NTumbleBit.Common;
 using NTumbleBit.Common.Logging;
 
 namespace NTumbleBit.Client.Tumbler

--- a/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
+++ b/NTumbleBit.Client/Tumbler/PaymentStateMachine.cs
@@ -324,10 +324,4 @@ namespace NTumbleBit.Client.Tumbler
 				throw new PuzzleException(error);
 		}
 	}
-
-	internal enum TumbleBitIdentity
-	{
-		Alice,
-		Bob
-	}
 }

--- a/NTumbleBit.Client/Tumbler/TumblerClient.cs
+++ b/NTumbleBit.Client/Tumbler/TumblerClient.cs
@@ -41,7 +41,7 @@ namespace NTumbleBit.Client.Tumbler
 		}
 
 	    public readonly DotNetTor.ControlPort.Client TorControl;
-		
+
 	    public async Task<bool> ChangeIpIfTorAsync()
 	    {
 		    if(TorControl != null)

--- a/NTumbleBit.Client/Tumbler/TumblerClient.cs
+++ b/NTumbleBit.Client/Tumbler/TumblerClient.cs
@@ -28,13 +28,25 @@ namespace NTumbleBit.Client.Tumbler
 			if(torParameters != null)
 			{
 				Client = new HttpClient(new SocksPortHandler(torParameters.Host, torParameters.SocksPort));
+				TorControl = new DotNetTor.ControlPort.Client(
+					torParameters.Host,
+					torParameters.ControlPort,
+					torParameters.ControlPortPassword);
 			}
 			else
 			{
+				TorControl = null;
 				Client = new HttpClient();
 			}
-
 		}
+
+	    public readonly DotNetTor.ControlPort.Client TorControl;
+
+	    public async Task ChangeIpIfTorAsync()
+	    {
+			if(TorControl != null)
+				await TorControl.ChangeCircuitAsync().ConfigureAwait(false);
+	    }
 
 	    private readonly Network _Network;
 		public Network Network

--- a/NTumbleBit.Client/Tumbler/TumblerClient.cs
+++ b/NTumbleBit.Client/Tumbler/TumblerClient.cs
@@ -41,11 +41,15 @@ namespace NTumbleBit.Client.Tumbler
 		}
 
 	    public readonly DotNetTor.ControlPort.Client TorControl;
-
-	    public async Task ChangeIpIfTorAsync()
+		
+	    public async Task<bool> ChangeIpIfTorAsync()
 	    {
-			if(TorControl != null)
-				await TorControl.ChangeCircuitAsync().ConfigureAwait(false);
+		    if(TorControl != null)
+		    {
+			    await TorControl.ChangeCircuitAsync().ConfigureAwait(false);
+				return true;
+		    }
+			else return false;
 	    }
 
 	    private readonly Network _Network;

--- a/NTumbleBit.Client/Tumbler/TumblerClient.cs
+++ b/NTumbleBit.Client/Tumbler/TumblerClient.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using DotNetTor.SocksPort;
+using NTumbleBit.Common.Logging;
 
 namespace NTumbleBit.Client.Tumbler
 {
@@ -22,54 +23,33 @@ namespace NTumbleBit.Client.Tumbler
 				throw new ArgumentNullException(nameof(serverAddress));
 			if(network == null)
 				throw new ArgumentNullException(nameof(network));
-			_Address = serverAddress;
-			_Network = network;
 
 			if(torParameters != null)
 			{
 				Client = new HttpClient(new SocksPortHandler(torParameters.Host, torParameters.SocksPort));
-				TorControl = new DotNetTor.ControlPort.Client(
+				_torControl = new DotNetTor.ControlPort.Client(
 					torParameters.Host,
 					torParameters.ControlPort,
 					torParameters.ControlPortPassword);
 			}
 			else
 			{
-				TorControl = null;
+				_torControl = null;
 				Client = new HttpClient();
 			}
+
+			Address = serverAddress;
+			Network = network;
+			TorParameters = torParameters;
+			Id = Guid.NewGuid();
 		}
 
-	    public readonly DotNetTor.ControlPort.Client TorControl;
-
-	    public async Task<bool> ChangeIpIfTorAsync()
-	    {
-		    if(TorControl != null)
-		    {
-			    await TorControl.ChangeCircuitAsync().ConfigureAwait(false);
-				return true;
-		    }
-			else return false;
-	    }
-
-	    private readonly Network _Network;
-		public Network Network
-		{
-			get
-			{
-				return _Network;
-			}
-		}
-
-
-		private readonly Uri _Address;
-		public Uri Address
-		{
-			get
-			{
-				return _Address;
-			}
-		}
+		public Network Network { get; }
+		public Uri Address { get; }
+		public Guid Id { get; }
+		public static Guid IdLastRequested = Guid.NewGuid();
+		public TorParameters TorParameters { get; }
+		private readonly DotNetTor.ControlPort.Client _torControl;
 
 	    private static HttpClient Client;
 		public Task<ClassicTumblerParameters> GetTumblerParametersAsync()
@@ -139,6 +119,13 @@ namespace NTumbleBit.Client.Tumbler
 
 	    private async Task<T> SendAsync<T>(HttpMethod method, object body, string relativePath, params object[] parameters)
 		{
+			// If using Tor and the last Id requested with is not the current one change circuits
+			if (_torControl != null && !IdLastRequested.Equals(Id))
+			{
+				IdLastRequested = Id;
+				await _torControl.ChangeCircuitAsync().ConfigureAwait(false);
+			}
+
 			var uri = GetFullUri(relativePath, parameters);
 			var message = new HttpRequestMessage(method, uri);
 			if(body != null)
@@ -208,8 +195,6 @@ namespace NTumbleBit.Client.Tumbler
 		{
 			return SendAsync<PuzzleSolver.ServerCommitment[]>(HttpMethod.Post, puzzles, "api/v1/tumblers/0/clientchannels/{0}/{1}/solvepuzzles", cycleId, channelId);
 		}
-
-
 
 		public PuzzlePromise.ServerCommitment[] SignHashes(int cycleId, string channelId, SignaturesRequest sigReq)
 		{

--- a/NTumbleBit.Client/Tumbler/TumblerClient.cs
+++ b/NTumbleBit.Client/Tumbler/TumblerClient.cs
@@ -10,12 +10,13 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using DotNetTor.SocksPort;
 
 namespace NTumbleBit.Client.Tumbler
 {
     public class TumblerClient
     {
-		public TumblerClient(Network network, Uri serverAddress)
+		public TumblerClient(Network network, Uri serverAddress, TorParameters torParameters = null)
 		{
 			if(serverAddress == null)
 				throw new ArgumentNullException(nameof(serverAddress));
@@ -23,10 +24,19 @@ namespace NTumbleBit.Client.Tumbler
 				throw new ArgumentNullException(nameof(network));
 			_Address = serverAddress;
 			_Network = network;
+
+			if(torParameters != null)
+			{
+				Client = new HttpClient(new SocksPortHandler(torParameters.Host, torParameters.SocksPort));
+			}
+			else
+			{
+				Client = new HttpClient();
+			}
+
 		}
 
-
-		private readonly Network _Network;
+	    private readonly Network _Network;
 		public Network Network
 		{
 			get
@@ -45,7 +55,7 @@ namespace NTumbleBit.Client.Tumbler
 			}
 		}
 
-	    private static readonly HttpClient Client = new HttpClient();
+	    private static HttpClient Client;
 		public Task<ClassicTumblerParameters> GetTumblerParametersAsync()
 		{
 			return GetAsync<ClassicTumblerParameters>("api/v1/tumblers/0/parameters");

--- a/NTumbleBit.Client/project.json
+++ b/NTumbleBit.Client/project.json
@@ -1,14 +1,15 @@
 {
     "version": "1.0.0-*",
 
-    "dependencies": {
-        "NBitcoin": "3.0.0.87",
-        "NETStandard.Library": "1.6.0",
-        "NTumbleBit": "1.0.0-*",
-        "NTumbleBit.Common": "1.0.0-*",
-        "DBreeze": "1.79.0",
-        "Microsoft.Extensions.Logging.Abstractions": "1.0.0"
-    },
+  "dependencies": {
+    "NBitcoin": "3.0.0.87",
+    "NETStandard.Library": "1.6.1",
+    "NTumbleBit": "1.0.0-*",
+    "NTumbleBit.Common": "1.0.0-*",
+    "DBreeze": "1.79.0",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
+    "DotNetTor": "2.1.2"
+  },
 
     "frameworks": {
         "netstandard1.6": {

--- a/NTumbleBit.Common/TextFileConfiguration.cs
+++ b/NTumbleBit.Common/TextFileConfiguration.cs
@@ -179,7 +179,7 @@ namespace NTumbleBit.Common
 
 		private T ConvertValue<T>(string str)
 		{
-			if(typeof(T) == typeof(bool))
+			if(typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
 			{
 				var trueValues = new[] { "1", "true" };
 				var falseValues = new[] { "0", "false" };
@@ -193,7 +193,7 @@ namespace NTumbleBit.Common
 				return (T)(object)new Uri(str, UriKind.Absolute);
 			else if(typeof(T) == typeof(string))
 				return (T)(object)str;
-			else if(typeof(T) == typeof(int))
+			else if(typeof(T) == typeof(int) || typeof(T) == typeof(int?))
 			{
 				return (T)(object)int.Parse(str, CultureInfo.InvariantCulture);
 			}


### PR DESCRIPTION
Tor integration. Do not merge, testing needed.  
  
You cannot test it on your local machine, since a Tor exit node cannot access your localhost.  
I set up a tumbler server, use that instead:  

`tumbler.server=http://146.185.160.175:5000`

Lines added to the `client.config` file:  
```
tor.use=true
tor.host=127.0.0.1
tor.socksport=9050
tor.controlport=9051
tor.controlportpassword=ILoveBitcoin21
```

# Tor instructions  
1. Download Tor Expert Bundle: https://www.torproject.org/download/download
2. Download the torrc config file sample: https://github.com/nopara73/DotNetTor/blob/master/torrc
3. Place torrc in the proper default location (depending on your OS) and edit it:
  - Optionally uncomment and edit the SocksPort, if you don't uncomment it will default to 9050 port anyway
  - The default ControlPort in the sample is 9051, optionally edit it.
  - Modify the password hash
    - To run my tests, for the `ControlPortPassword = "ILoveBitcoin21"` the hash should be: `HashedControlPassword 16:0978DBAF70EEB5C46063F3F6FD8CBC7A86DF70D2206916C1E2AE29EAF6`
    - For your application you should use different one, a more complicated one. Then start tor like this: `tor --hash-password password`
      where password is the `password` you've chosen. It will give you the `HashedControlPassword`.
4. Start tor, it will listen to the ports you set in the config file.