### PR TITLE
Harden RSA against timing attacks

### DIFF
--- a/NTumbleBit/BouncyCastle/crypto/engines/RSABlindedEngine.cs
+++ b/NTumbleBit/BouncyCastle/crypto/engines/RSABlindedEngine.cs
@@ -1,0 +1,131 @@
+using System;
+
+using NTumbleBit.BouncyCastle.Crypto.Parameters;
+using NTumbleBit.BouncyCastle.Math;
+using NTumbleBit.BouncyCastle.Security;
+using NTumbleBit.BouncyCastle.Utilities;
+
+namespace NTumbleBit.BouncyCastle.Crypto.Engines
+{
+
+    /**
+    NOTE: MODIFIED FROM ORIGINAL VERSION 
+
+    - `ProcessBlock` was modified to accept BigInteger as input and output BigInteger
+    - Added `ConvertOutput` that convert BigInteger to byte[]
+    */
+
+    /**
+     * this does your basic RSA algorithm with blinding
+     */
+    internal class RsaBlindedEngine
+        // : IAsymmetricBlockCipher
+    {
+        private readonly RsaCoreEngine core = new RsaCoreEngine();
+        private RsaKeyParameters key;
+        private SecureRandom random;
+
+        public virtual string AlgorithmName
+        {
+            get { return "RSA"; }
+        }
+
+        /**
+         * initialise the RSA engine.
+         *
+         * @param forEncryption true if we are encrypting, false otherwise.
+         * @param param the necessary RSA key parameters.
+         */
+        public virtual void Init(
+            bool forEncryption,
+            ICipherParameters param)
+        {
+            core.Init(forEncryption, param);
+
+            if (param is ParametersWithRandom)
+            {
+                ParametersWithRandom rParam = (ParametersWithRandom)param;
+
+                key = (RsaKeyParameters)rParam.Parameters;
+                random = rParam.Random;
+            }
+            else
+            {
+                key = (RsaKeyParameters)param;
+                random = new SecureRandom();
+            }
+        }
+
+        public virtual byte[] ConvertOutput(
+			BigInteger result)
+		{
+            return core.ConvertOutput(result);
+		}
+
+
+        /**
+         * Return the maximum size for an input block to this engine.
+         * For RSA this is always one byte less than the key size on
+         * encryption, and the same length as the key size on decryption.
+         *
+         * @return maximum size for an input block.
+         */
+        public virtual int GetInputBlockSize()
+        {
+            return core.GetInputBlockSize();
+        }
+
+        /**
+         * Return the maximum size for an output block to this engine.
+         * For RSA this is always one byte less than the key size on
+         * decryption, and the same length as the key size on encryption.
+         *
+         * @return maximum size for an output block.
+         */
+        public virtual int GetOutputBlockSize()
+        {
+            return core.GetOutputBlockSize();
+        }
+
+        public virtual BigInteger ProcessBlock(BigInteger input)
+        {
+            if (key == null)
+                throw new InvalidOperationException("RSA engine not initialised");
+
+            // BigInteger input = core.ConvertInput(inBuf, inOff, inLen);
+
+            BigInteger result;
+            if (key is RsaPrivateCrtKeyParameters)
+            {
+                RsaPrivateCrtKeyParameters k = (RsaPrivateCrtKeyParameters)key;
+                BigInteger e = k.PublicExponent;
+                if (e != null)   // can't do blinding without a public exponent
+                {
+                    BigInteger m = k.Modulus;
+                    BigInteger r = BigIntegers.CreateRandomInRange(
+                        BigInteger.One, m.Subtract(BigInteger.One), random);
+
+                    BigInteger blindedInput = r.ModPow(e, m).Multiply(input).Mod(m);
+                    BigInteger blindedResult = core.ProcessBlock(blindedInput);
+
+                    BigInteger rInv = r.ModInverse(m);
+                    result = blindedResult.Multiply(rInv).Mod(m);
+
+                    // defence against Arjen Lenstra�s CRT attack
+                    if (!input.Equals(result.ModPow(e, m)))
+                        throw new InvalidOperationException("RSA engine faulty decryption/signing detected");
+                }
+                else
+                {
+                    result = core.ProcessBlock(input);
+                }
+            }
+            else
+            {
+                result = core.ProcessBlock(input);
+            }
+
+            return result;
+        }
+    }
+}

--- a/NTumbleBit/BouncyCastle/crypto/parameters/ParametersWithRandom.cs
+++ b/NTumbleBit/BouncyCastle/crypto/parameters/ParametersWithRandom.cs
@@ -1,0 +1,48 @@
+using System;
+
+using NTumbleBit.BouncyCastle.Security;
+
+namespace NTumbleBit.BouncyCastle.Crypto.Parameters
+{
+    internal class ParametersWithRandom
+		: ICipherParameters
+    {
+        private readonly ICipherParameters	parameters;
+		private readonly SecureRandom		random;
+
+		public ParametersWithRandom(
+            ICipherParameters	parameters,
+            SecureRandom		random)
+        {
+			if (parameters == null)
+				throw new ArgumentNullException("parameters");
+			if (random == null)
+				throw new ArgumentNullException("random");
+
+			this.parameters = parameters;
+			this.random = random;
+		}
+
+		public ParametersWithRandom(
+            ICipherParameters parameters)
+			: this(parameters, new SecureRandom())
+        {
+		}
+
+		[Obsolete("Use Random property instead")]
+		public SecureRandom GetRandom()
+		{
+			return Random;
+		}
+
+		public SecureRandom Random
+        {
+			get { return random; }
+        }
+
+		public ICipherParameters Parameters
+        {
+            get { return parameters; }
+        }
+    }
+}

--- a/NTumbleBit/RsaKey.cs
+++ b/NTumbleBit/RsaKey.cs
@@ -80,8 +80,9 @@ namespace NTumbleBit
 				var input = new BigInteger(1, output);
 				if(input.CompareTo(_Key.Modulus) >= 0)
 					continue;
-				var engine = new RsaCoreEngine();
+				var engine = new RsaBlindedEngine();
 				engine.Init(true, _Key);
+
 				return engine.ConvertOutput(engine.ProcessBlock(input));
 			}
 		}
@@ -93,7 +94,7 @@ namespace NTumbleBit
 			if(encrypted.CompareTo(_Key.Modulus) >= 0)
 				throw new DataLengthException("input too large for RSA cipher.");
 
-			RsaCoreEngine engine = new RsaCoreEngine();
+			RsaBlindedEngine engine = new RsaBlindedEngine();
 			engine.Init(false, _Key);
 			return engine.ProcessBlock(encrypted);
 		}

--- a/NTumbleBit/RsaPubKey.cs
+++ b/NTumbleBit/RsaPubKey.cs
@@ -74,7 +74,7 @@ namespace NTumbleBit
 			var signatureInt = new BigInteger(1, signature);
 			if(signatureInt.CompareTo(_Key.Modulus) >= 0)
 				return false;
-			var engine = new RsaCoreEngine();
+			var engine = new RsaBlindedEngine();
 			engine.Init(false, _Key);
 			return input.Equals(engine.ProcessBlock(signatureInt));
 		}
@@ -96,7 +96,8 @@ namespace NTumbleBit
 				throw new ArgumentNullException(nameof(data));
 			if(data.CompareTo(_Key.Modulus) >= 0)
 				throw new ArgumentException("input too large for RSA cipher.");
-			RsaCoreEngine engine = new RsaCoreEngine();
+				
+			RsaBlindedEngine engine = new RsaBlindedEngine();
 			engine.Init(true, _Key);
 			return engine.ProcessBlock(data);
 		}


### PR DESCRIPTION
Protect RSA private key by blinding input before doing any operation using the private key. 

Changed the RSA engine from RsaCoreEngine to RsaBlindedEngine that does the blinding step on the input. Had to modify the source of RsaBlindedEngine from the original version to avoid breaking anything in NTumblebit. 