### PR TITLE
fix blocks for estimatefee

### DIFF
--- a/NTumbleBit.TumblerServer/Services/RPCServices/RPCFeeService.cs
+++ b/NTumbleBit.TumblerServer/Services/RPCServices/RPCFeeService.cs
@@ -30,7 +30,7 @@ namespace NTumbleBit.Client.Tumbler.Services.RPCServices
 		}
 		public FeeRate GetFeeRate()
 		{
-			return _RPCClient.TryEstimateFeeRate(1) ?? new FeeRate(Money.Satoshis(50), 1);
+			return _RPCClient.TryEstimateFeeRate(2) ?? new FeeRate(Money.Satoshis(50), 1);
 		}
 	}
 }


### PR DESCRIPTION
Blocks for estimagefee command of bitcoind in NTumbleBit is 1.
But if 1 block then the command returns -1 from bitcoind 0.14.0.

https://bitcoincore.org/en/releases/0.14.0/
"Fee Estimation Changes"

So I fix the block from 1 to 2 to work the estimation.