### PR TITLE
Change default port from 5000 to 37123

### DIFF
--- a/NTumbleBit.TumblerServer/Properties/launchSettings.json
+++ b/NTumbleBit.TumblerServer/Properties/launchSettings.json
@@ -18,9 +18,9 @@
     },
     "NTumbleBit.TumblerServer": {
       "commandName": "Project",
-      "commandLineArgs": "-port 5000",
+      "commandLineArgs": "-port 37123",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:5000",
+      "launchUrl": "http://localhost:37123",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/NTumbleBit.TumblerServer/TumblerConfiguration.cs
+++ b/NTumbleBit.TumblerServer/TumblerConfiguration.cs
@@ -148,7 +148,7 @@ namespace NTumbleBit.TumblerServer
 				Environment.Exit(0);
 			}
 
-			var defaultPort = config.GetOrDefault<int>("port", 5000);
+			var defaultPort = config.GetOrDefault<int>("port", 37123);
 
 			OnlyMonitor = config.GetOrDefault<bool>("onlymonitor", false);
 			Listen = config


### PR DESCRIPTION
The default port must be changed eventually.  I've chosen this number, because it's in the middle of a long range of unassigned IANA ports, comes exactly after the ports HiddenWallet uses (37120, 37121, 37122).  
[I also documented the ports of the related softwares here.](https://github.com/nopara73/HiddenWallet/blob/master/HiddenWallet/HiddenWallet.Docs/Ports.md)

|Port | Application |
|---- | ---- |
|37120  | HiddenWallet API |
|37121  | Tor socks port used by HiddenWallet |
|37122  | Tor control port used by HiddenWallet |
|37123  | NTumbleBit server |
|9050  | Default Tor socks port |
|9051  | Default Tor control port |
|9150  | Tor socks port used by Tor Browser |
|9151  | Tor control port used by Tor Browser |
|8333  | Bitcoin Core RPC |
|  | Stratis: Breeze Wallet API |