### PR TITLE
Tor integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,5 @@ ModelManifest.xml
 Tumbler.pem
 Seed.dat
 TestData/
+TorData
+/NTumbleBit.ClassicTumbler.Client.CLI/torchangelog.txt

--- a/NTumbleBit.ClassicTumbler.Client.CLI/Program.cs
+++ b/NTumbleBit.ClassicTumbler.Client.CLI/Program.cs
@@ -10,6 +10,10 @@ using NTumbleBit.ClassicTumbler;
 using NTumbleBit.Configuration;
 using NTumbleBit.ClassicTumbler.Client;
 using NTumbleBit.ClassicTumbler.CLI;
+using System.Diagnostics;
+using System.IO;
+using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace NTumbleBit.ClassicTumbler.Client.CLI
 {
@@ -25,11 +29,66 @@ namespace NTumbleBit.ClassicTumbler.Client.CLI
 
 			using(var interactive = new Interactive())
 			{
-
+				Tor.TorProcess = null;
 				try
 				{
 					var config = new TumblerClientConfiguration();
 					config.LoadArgs(args);
+
+
+					#region TorSetup
+					// If the server is on the same machine TOR would refuse the connection, in this case go without Tor
+					if (config.TumblerServer.DnsSafeHost == "10.0.2.2" || // VM host
+						config.TumblerServer.DnsSafeHost.Equals("localhost", StringComparison.OrdinalIgnoreCase) ||
+						config.TumblerServer.DnsSafeHost == "127.0.0.1" || // localhost
+						config.TumblerServer.DnsSafeHost == "0.0.0.0") // localhost
+					{
+						Tor.UseTor = false;
+						Logs.Configuration.LogInformation("Did not start Tor. Reason: The tumbler server is running on the same machine.");
+					}
+					else
+					{
+						Tor.UseTor = true;
+
+						var torProcessStartInfo = new ProcessStartInfo("tor")
+						{
+							Arguments = Tor.TorArguments,
+							UseShellExecute = false,
+							CreateNoWindow = true,
+							RedirectStandardOutput = true
+						};
+
+						try
+						{
+							// if doesn't fail tor is already running with the control port
+							Tor.ControlPortClient.IsCircuitEstabilishedAsync().Wait();
+							Logs.Configuration.LogInformation($"Tor is already running, using the existing instance.");
+						}
+						catch
+						{
+							Logs.Configuration.LogInformation($"Starting Tor with arguments: {Tor.TorArguments}");
+							try
+							{
+								Tor.TorProcess = Process.Start(torProcessStartInfo);
+							}
+							catch (Exception ex) when (ex is FileNotFoundException || ex is Win32Exception)
+							{
+								// https://msdn.microsoft.com/en-us/library/0w4h05yb(v=vs.110).aspx
+								// According to MSDN it should be FileNotFoundException, but in reality it throws Win32Exception
+								throw new ConfigException("Couldn't start Tor process. Make sure Tor is in your PATH.");
+							}
+						}
+						Logs.Configuration.LogInformation($"Estabilishing Tor circuit.");
+						#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+						Tor.MakeSureCircuitEstabilishedAsync();
+						while(Tor.State != Tor.TorState.CircuitEstabilished)
+						{
+							Task.Delay(100).Wait();
+						}
+						#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+						Logs.Configuration.LogInformation($"Tor circuit is estabilished.");
+					}
+					#endregion
 
 					ClassicTumblerParameters toConfirm;
 					var runtime = TumblerClientRuntime.FromConfiguration(config, out toConfirm);
@@ -68,6 +127,13 @@ namespace NTumbleBit.ClassicTumbler.Client.CLI
 				{
 					Logs.Configuration.LogError(ex.Message);
 					Logs.Configuration.LogDebug(ex.StackTrace);
+				}
+				finally
+				{
+					if (Tor.UseTor)
+					{
+						Tor.Kill();
+					}
 				}
 			}
 		}

--- a/NTumbleBit.Tests/TumblerServerTester.cs
+++ b/NTumbleBit.Tests/TumblerServerTester.cs
@@ -29,7 +29,7 @@ namespace NTumbleBit.Tests
 			{
 
 				var rootTestData = "TestData";
-				directory = rootTestData + "/" + directory;
+				directory = Path.Combine(rootTestData, directory);
 				_Directory = directory;
 				if(!Directory.Exists(rootTestData))
 					Directory.CreateDirectory(rootTestData);
@@ -92,10 +92,8 @@ namespace NTumbleBit.Tests
 
 				var clientConfig = new TumblerClientConfiguration();
 				clientConfig.DataDir = Path.Combine(directory, "client");
-				clientConfig.AllowInsecure = true;
 				Directory.CreateDirectory(clientConfig.DataDir);
 				clientConfig.Network = conf.Network;
-				clientConfig.CheckIp = false;
 				clientConfig.OutputWallet.KeyPath = new KeyPath("0");
 				clientConfig.OutputWallet.RootKey = new ExtKey().Neuter().GetWif(conf.Network);
 				clientConfig.RPCArgs.Url = AliceNode.CreateRPCClient().Address;

--- a/NTumbleBit.Tests/TumblerServerTests.cs
+++ b/NTumbleBit.Tests/TumblerServerTests.cs
@@ -17,7 +17,7 @@ namespace NTumbleBit.Tests
 			using(var server = TumblerServerTester.Create())
 			{
 				var client = server.CreateTumblerClient();
-				var parameters = client.GetTumblerParameters();
+				var parameters = client.GetTumblerParameters(Identity.DoesntMatter);
 				Assert.NotNull(parameters.ServerKey);
 				Assert.NotEqual(0, parameters.RealTransactionCount);
 				Assert.NotEqual(0, parameters.FakeTransactionCount);
@@ -146,8 +146,8 @@ namespace NTumbleBit.Tests
 
 
 
-				var escrow1 = machine.AliceClient.RequestTumblerEscrowKey(machine.StartCycle);
-				var escrow2 = machine.AliceClient.RequestTumblerEscrowKey(machine.StartCycle);
+				var escrow1 = machine.Client.RequestTumblerEscrowKey(Identity.DoesntMatter, machine.StartCycle);
+				var escrow2 = machine.Client.RequestTumblerEscrowKey(Identity.DoesntMatter, machine.StartCycle);
 				Assert.Equal(0, escrow1.KeyIndex);
 				Assert.Equal(1, escrow2.KeyIndex);
 				machine.Update();

--- a/NTumbleBit/ClassicTumbler/Client/Identity.cs
+++ b/NTumbleBit/ClassicTumbler/Client/Identity.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NTumbleBit.ClassicTumbler.Client
+{
+    public class Identity : IEquatable<Identity>
+    {
+		private Role _role { get; }
+		private int _cycle { get; }
+
+		private bool _doesntMatter { get; }
+		public static Identity DoesntMatter => new Identity(doesntMatter: true);
+
+		public Identity(Role role, int cycle)
+		{
+			_role = role;
+			_cycle = cycle;
+			_doesntMatter = false;
+		}
+		
+		/// <param name="doesntMatter">Only accept true</param>
+		private Identity(bool doesntMatter)
+		{
+			if (!doesntMatter) throw new ArgumentException(nameof(doesntMatter));
+			_doesntMatter = doesntMatter;
+
+			// dummy
+			_role = Role.Alice;
+			_cycle = -1;
+		}
+
+		public override string ToString()
+		{
+			if (_doesntMatter) return "'Does not matter'";
+			else return $"{_role} {_cycle}";
+		}
+
+		#region Equality
+		public static bool operator ==(Identity a1, Identity a2) => 
+			a1._doesntMatter
+			|| a2._doesntMatter
+			|| (a1._role == a2._role && a1._cycle == a2._cycle);
+		public static bool operator !=(Identity a1, Identity a2) => !(a1 == a2);
+		public override bool Equals(object obj) => obj is Identity && this == (Identity)obj;
+		public bool Equals(Identity other) => this == other;
+		public override int GetHashCode() => 
+			_doesntMatter 
+			? _doesntMatter.GetHashCode()
+			: _role.GetHashCode() ^ _cycle.GetHashCode();		
+		#endregion
+	}
+	public enum Role
+	{
+		Alice,
+		Bob
+	}
+}

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClient.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClient.cs
@@ -125,22 +125,28 @@ namespace NTumbleBit.ClassicTumbler.Client
 			{
 				message.Content = new StringContent(Serializer.ToString(body, Network), Encoding.UTF8, "application/json");
 			}
-
+			
 			if (Tor.UseTor)
 			{
+				// torchangelog.txt for testing only, before merge to master it should be deleted
+				if(who == new Identity(Role.Alice, -1))
+				{
+					File.AppendAllText("torchangelog.txt", Environment.NewLine + Environment.NewLine + "//RESTART" + Environment.NewLine);
+				}
+
 				if (who != CurrentIdentity)
 				{
 					var start = DateTime.Now;
 					Logs.Client.LogInformation($"Changing identity to {who}");
 					await Tor.ControlPortClient.ChangeCircuitAsync().ConfigureAwait(false);
-					var takelong = start - DateTime.Now;
+					var takelong = DateTime.Now - start;
 					File.AppendAllText("torchangelog.txt", Environment.NewLine + Environment.NewLine + $"CHANGE IP: {(int)takelong.TotalSeconds} sec" + Environment.NewLine);
 				}
 				CurrentIdentity = who;
+				File.AppendAllText("torchangelog.txt", '\t' + who.ToString() + Environment.NewLine);
+				File.AppendAllText("torchangelog.txt", '\t' + message.Method.Method + " " + message.RequestUri.AbsolutePath + Environment.NewLine);
 			}
 
-			File.AppendAllText("torchangelog.txt", '\t' + who.ToString() + Environment.NewLine);
-			File.AppendAllText("torchangelog.txt", '\t' + message.Method.Method + " " + message.RequestUri.AbsolutePath + Environment.NewLine);
 			HttpResponseMessage result;
 			try
 			{

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientConfiguration.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientConfiguration.cs
@@ -29,18 +29,6 @@ namespace NTumbleBit.ClassicTumbler.Client
 		}
 	}
 
-	public class ConnectionSettings
-	{
-		public Uri Proxy
-		{
-			get; set;
-		}
-		public NetworkCredential Credentials
-		{
-			get; set;
-		}
-	}
-
 	public class TumblerClientConfiguration
 	{
 		public string ConfigurationFile
@@ -64,11 +52,6 @@ namespace NTumbleBit.ClassicTumbler.Client
 			get; set;
 		}
 
-		public bool CheckIp
-		{
-			get; set;
-		} = true;
-
 		public bool Cooperative
 		{
 			get;
@@ -80,16 +63,6 @@ namespace NTumbleBit.ClassicTumbler.Client
 			set;
 		}
 
-		public ConnectionSettings BobConnectionSettings
-		{
-			get; set;
-		} = new ConnectionSettings();
-
-		public ConnectionSettings AliceConnectionSettings
-		{
-			get; set;
-		} = new ConnectionSettings();
-
 		public OutputWalletConfiguration OutputWallet
 		{
 			get; set;
@@ -99,11 +72,6 @@ namespace NTumbleBit.ClassicTumbler.Client
 		{
 			get; set;
 		} = new RPCArgs();
-		public bool AllowInsecure
-		{
-			get;
-			set;
-		} = false;
 
 		public TumblerClientConfiguration LoadArgs(String[] args)
 		{
@@ -194,29 +162,12 @@ namespace NTumbleBit.ClassicTumbler.Client
 
 			OutputWallet.RPCArgs = RPCArgs.Parse(config, Network, "outputwallet");
 
-			AliceConnectionSettings = ParseConnectionSettings("alice", config);
-			BobConnectionSettings = ParseConnectionSettings("bob", config);
-
-			AllowInsecure = config.GetOrDefault<bool>("allowinsecure", IsTest(Network));
 			return this;
 		}
 
 		private bool IsTest(Network network)
 		{
 			return network == Network.TestNet || network == Network.RegTest;
-		}
-
-		private ConnectionSettings ParseConnectionSettings(string prefix, TextFileConfiguration config)
-		{
-			ConnectionSettings settings = new ConnectionSettings();
-			var server = config.GetOrDefault<Uri>(prefix + ".proxy.server", null);
-			if(server != null)
-				settings.Proxy = server;
-			var user = config.GetOrDefault<string>(prefix + ".proxy.username", null);
-			var pass = config.GetOrDefault<string>(prefix + ".proxy.password", null);
-			if(user != null && pass != null)
-				settings.Credentials = new NetworkCredential(user, pass);
-			return settings;
 		}
 
 		public static string GetDefaultConfigurationFile(string dataDirectory, Network network)
@@ -240,16 +191,6 @@ namespace NTumbleBit.ClassicTumbler.Client
 				builder.AppendLine("#Configuration of the output wallet");
 				builder.AppendLine("#outputwallet.extpubkey=xpub");
 				builder.AppendLine("#outputwallet.keypath=0");
-				builder.AppendLine();
-				builder.AppendLine();
-				builder.AppendLine("####Connection Commands####");
-				builder.AppendLine("#A TumbleBit client should use the Tumbler under two different identity. We recommend to make Alice using a HTTP proxy masking her real IP address. (For example privoxy with TOR)");
-				builder.AppendLine("#alice.proxy.server=http://127.0.0.1:8118/");
-				builder.AppendLine("#bob.proxy.server=http://127.0.0.1:8118/");
-				builder.AppendLine("#alice.proxy.username=dpowqkwkpd");
-				builder.AppendLine("#bob.proxy.username=dpowqkwkpd");
-				builder.AppendLine("#alice.proxy.password=padeiwmnfw");
-				builder.AppendLine("#bob.proxy.password=padeiwmnfw");
 
 				builder.AppendLine();
 				builder.AppendLine();
@@ -257,8 +198,6 @@ namespace NTumbleBit.ClassicTumbler.Client
 				builder.AppendLine("####Debug Commands####");
 				builder.AppendLine("#Whether or not signature for the escape transaction is transmitted to the Tumbler (default: true)");
 				builder.AppendLine("#cooperative=false");
-				builder.AppendLine("#Whether or not IP sharing between Bob and Alice is authorized (default: true for testnets, false for mainnet)");
-				builder.AppendLine("#allowinsecure=true");
 				File.WriteAllText(config, builder.ToString());				
 			}
 			return config;

--- a/NTumbleBit/Extensions.cs
+++ b/NTumbleBit/Extensions.cs
@@ -23,5 +23,14 @@ namespace NTumbleBit
 		{
 			return new ScriptCoin(scriptCoin, scriptCoin.Redeem);
 		}
+
+		public static async Task<TResult> WithTimeout<TResult>(this Task<TResult> task, TimeSpan timeout)
+		{
+			if (task == await Task.WhenAny(task, Task.Delay(timeout)))
+			{
+				return await task;
+			}
+			throw new TimeoutException();
+		}
 	}
 }

--- a/NTumbleBit/NTumbleBit.csproj
+++ b/NTumbleBit/NTumbleBit.csproj
@@ -10,13 +10,14 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="DBreeze" Version="1.84.0" />
+    <PackageReference Include="DotNetTor" Version="2.2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.2" />
-    <PackageReference Include="NBitcoin" Version="4.0.0.5" />
+    <PackageReference Include="NBitcoin" Version="4.0.0.8" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/NTumbleBit/Tor.cs
+++ b/NTumbleBit/Tor.cs
@@ -1,0 +1,119 @@
+﻿using DotNetTor.SocksPort;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using NTumbleBit.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace NTumbleBit
+{
+	public static class Tor
+	{
+		public static Process TorProcess = null;
+		public static bool UseTor = false;
+		public const int SOCKSPort = 37124;
+		public const int ControlPort = 37125;
+		public const string HashedControlPassword = "16:0978DBAF70EEB5C46063F3F6FD8CBC7A86DF70D2206916C1E2AE29EAF6";
+		public const string DataDirectory = "TorData";
+		public static string TorArguments => $"SOCKSPort {SOCKSPort} ControlPort {ControlPort} HashedControlPassword {HashedControlPassword} DataDirectory {DataDirectory}";
+		public static SocksPortHandler SocksPortHandler = new SocksPortHandler("127.0.0.1", socksPort: SOCKSPort);
+		public static DotNetTor.ControlPort.Client ControlPortClient = new DotNetTor.ControlPort.Client("127.0.0.1", controlPort: ControlPort, password: "ILoveBitcoin21");
+		public static TorState State = TorState.NotStarted;
+		public static CancellationTokenSource CircuitEstabilishingJobCancel = new CancellationTokenSource();
+
+		public static async Task MakeSureCircuitEstabilishedAsync()
+		{
+			var ctsToken = CircuitEstabilishingJobCancel.Token;
+			State = TorState.NotStarted;
+			while (true)
+			{
+				try
+				{
+					if (ctsToken.IsCancellationRequested) return;
+
+					try
+					{
+						var estabilished = await ControlPortClient.IsCircuitEstabilishedAsync().WithTimeout(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+						if (ctsToken.IsCancellationRequested) return;
+
+						if (estabilished)
+						{
+							State = TorState.CircuitEstabilished;
+						}
+						else
+						{
+							State = TorState.EstabilishingCircuit;
+						}
+					}
+					catch (Exception ex)
+					{
+						if (ex is TimeoutException || ex.InnerException is TimeoutException)
+						{
+							// Tor messed up something internally, this sometimes happens when it creates new datadir (at first launch)
+							// Restarting solves the issue
+							await RestartAsync().ConfigureAwait(false);
+						}
+						if (ctsToken.IsCancellationRequested) return;
+					}
+				}
+				catch(Exception ex)
+				{
+					Logs.Client.LogInformation("Ignoring Tor exception");
+					Logs.Client.LogInformation(ex.ToString());
+				}
+
+				if (State == TorState.CircuitEstabilished)
+				{
+					return;
+				}
+				var wait = TimeSpan.FromSeconds(3);
+				await Task.Delay(wait, ctsToken).ContinueWith(tsk => { }).ConfigureAwait(false);
+			}
+		}
+
+		public static async Task RestartAsync()
+		{
+			Kill();
+
+			await Task.Delay(3000).ContinueWith(tsk => { }).ConfigureAwait(false);
+
+			try
+			{
+				Logs.Client.LogInformation("Starting Tor process.");
+				TorProcess.Start();
+
+				CircuitEstabilishingJobCancel = new CancellationTokenSource();
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+				MakeSureCircuitEstabilishedAsync();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+			}
+			catch (Exception ex)
+			{
+				Logs.Client.LogInformation("Ignoring Tor exception:");
+				Logs.Client.LogInformation(ex.ToString());
+				State = TorState.NotStarted;
+			}
+		}
+
+		public static void Kill()
+		{
+			CircuitEstabilishingJobCancel.Cancel();
+			State = TorState.NotStarted;
+			if (TorProcess != null && !TorProcess.HasExited)
+			{
+				Logs.Client.LogInformation("Terminating Tor process.");
+				TorProcess.Kill();
+			}
+		}
+
+		public enum TorState
+		{
+			NotStarted,
+			EstabilishingCircuit,
+			CircuitEstabilished
+		}
+	}
+}


### PR DESCRIPTION
I finished the Tor integration and tested it on Ubuntu and Windows 7. It works flawlessly.  
  
# Setting up Tor  
  
There is no need for the user to do any settings manually, except that the user has to make sure Tor is in the PATH of its operating system.  
  
# Local vs remote
If the Tumbler is running locally, it will not use Tor. Therefore a remote server is needed for testing. For this purpose I used @NicolasDorier 's testnet tumbler server, which can be set up in the client.config file as follows: `tumbler.server=http://testnet.ntumblebit.metaco.com`.  

# What it does?  
  
Whenever any HTTP request is sent to the Tumbler the it checks if the identity the software wants to send the request is the same as the last request was sent with and if it's not it chanes Tor circuit, before the request is sent.  
  
An identity is defined by TumbleBit's Alice Bob role's and the cycle they are in.  

## Example:  
```
CHANGE IP: 0 sec
	Alice 1152052
	POST /api/v1/tumblers/0/clientchannels/confirm


CHANGE IP: 4 sec
	Alice 1152054
	POST /api/v1/tumblers/0/clientchannels/


CHANGE IP: 0 sec
	Bob 1152052
	POST /api/v1/tumblers/0/channels/
	Bob 1152052
	POST /api/v1/tumblers/0/channels/1152052/a914ae1cb6ddde39f7b9fe4d8027fbe06809d8d057cd87/signhashes
	Bob 1152052
	POST /api/v1/tumblers/0/channels/1152052/a914ae1cb6ddde39f7b9fe4d8027fbe06809d8d057cd87/checkrevelation


CHANGE IP: 0 sec
	Bob 1152058
	GET /api/v1/tumblers/0/vouchers/
```
  
# Additional notes / ToDo  
  
- [ ] Before merge -  I am writing a torchangelog.txt inside the NTumbleBit.ClassicTumbler.Client.CLI directory. This is a quick messy logging it must be removed. The output of this file is the example above.
- [ ] After merge - Update the wiki
  
# Big picture 
This is the last major milestone that'll make TumbleBit protocol implementation a complete Bitcoin anonymity technique. The rest is UX, bug fixing and optimization.  