### PR TITLE
Extract ExternalServices and TumblerClientConfiguration parent types

### DIFF
--- a/NTumbleBit.Tests/TumblerServerTester.cs
+++ b/NTumbleBit.Tests/TumblerServerTester.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNetCore.Hosting;
-using TCPServer;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Server.Kestrel;
 using NBitcoin;
 using NBitcoin.RPC;
 using NTumbleBit.ClassicTumbler;
@@ -19,7 +17,6 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using NTumbleBit.Services;
-using NTumbleBit.Configuration;
 
 namespace NTumbleBit.Tests
 {
@@ -67,7 +64,7 @@ namespace NTumbleBit.Tests
 				var conf = new TumblerConfiguration();
 				conf.DataDir = Path.Combine(directory, "server");
 
-                Directory.CreateDirectory(conf.DataDir);
+				Directory.CreateDirectory(conf.DataDir);
 				File.WriteAllBytes(Path.Combine(conf.DataDir, "Tumbler.pem"), TestKeys.Default.ToBytes());
 				File.WriteAllBytes(Path.Combine(conf.DataDir, "Voucher.pem"), TestKeys.Default2.ToBytes());
 				conf.RPC.Url = TumblerNode.CreateRPCClient().Address;
@@ -77,19 +74,19 @@ namespace NTumbleBit.Tests
 				conf.Network = Network.RegTest;
 				conf.Listen = new System.Net.IPEndPoint(IPAddress.Parse("127.0.0.1"), 5000);
 				conf.AllowInsecure = true;
-			    conf.DBreezeRepository = new DBreezeRepository(Path.Combine(conf.DataDir, "db2"));
-			    conf.Tracker = new Tracker(conf.DBreezeRepository, conf.Network);
+				conf.DBreezeRepository = new DBreezeRepository(Path.Combine(conf.DataDir, "db2"));
+				conf.Tracker = new Tracker(conf.DBreezeRepository, conf.Network);
 
-                conf.ClassicTumblerParameters.FakePuzzleCount /= 4;
+				conf.ClassicTumblerParameters.FakePuzzleCount /= 4;
 				conf.ClassicTumblerParameters.FakeTransactionCount /= 4;
 				conf.ClassicTumblerParameters.RealTransactionCount /= 4;
 				conf.ClassicTumblerParameters.RealPuzzleCount /= 4;
 				conf.ClassicTumblerParameters.CycleGenerator.FirstCycle.Start = 105;
 
-			    RPCClient rpc =  conf.RPC.ConfigureRPCClient(conf.Network);
-			    conf.Services = ExternalServices.CreateFromRPCClient(rpc, conf.DBreezeRepository, conf.Tracker);
+				RPCClient rpc =  conf.RPC.ConfigureRPCClient(conf.Network);
+				conf.Services = ExternalServices.CreateFromRPCClient(rpc, conf.DBreezeRepository, conf.Tracker);
 
-                var runtime = TumblerRuntime.FromConfiguration(conf, new AcceptAllClientInteraction());
+				var runtime = TumblerRuntime.FromConfiguration(conf, new AcceptAllClientInteraction());
 				_Host = new WebHostBuilder()
 					.UseAppConfiguration(runtime)
 					.UseContentRoot(Path.GetFullPath(directory))
@@ -115,14 +112,14 @@ namespace NTumbleBit.Tests
 				creds = ExtractCredentials(File.ReadAllText(AliceNode.Config));
 				clientConfig.RPCArgs.User = creds.Item1;
 				clientConfig.RPCArgs.Password = creds.Item2;
-			    clientConfig.DBreezeRepository = new DBreezeRepository(Path.Combine(clientConfig.DataDir, "db2"));
-			    clientConfig.Tracker = new Tracker(clientConfig.DBreezeRepository, clientConfig.Network);
-                clientConfig.TumblerServer = runtime.TumblerUris.First();
+				clientConfig.DBreezeRepository = new DBreezeRepository(Path.Combine(clientConfig.DataDir, "db2"));
+				clientConfig.Tracker = new Tracker(clientConfig.DBreezeRepository, clientConfig.Network);
+				clientConfig.TumblerServer = runtime.TumblerUris.First();
 
-			    RPCClient rpcClient =  clientConfig.RPCArgs.ConfigureRPCClient(clientConfig.Network);			    
-			    clientConfig.Services = ExternalServices.CreateFromRPCClient(rpcClient, clientConfig.DBreezeRepository, clientConfig.Tracker);
-                clientConfig.DestinationWallet = new ClientDestinationWallet(clientConfig.OutputWallet.RootKey, clientConfig.OutputWallet.KeyPath, clientConfig.DBreezeRepository, clientConfig.Network);
-                ClientRuntime = TumblerClientRuntime.FromConfiguration(clientConfig, new AcceptAllClientInteraction());
+				RPCClient rpcClient =  clientConfig.RPCArgs.ConfigureRPCClient(clientConfig.Network);			    
+				clientConfig.Services = ExternalServices.CreateFromRPCClient(rpcClient, clientConfig.DBreezeRepository, clientConfig.Tracker);
+				clientConfig.DestinationWallet = new ClientDestinationWallet(clientConfig.OutputWallet.RootKey, clientConfig.OutputWallet.KeyPath, clientConfig.DBreezeRepository, clientConfig.Network);
+				ClientRuntime = TumblerClientRuntime.FromConfiguration(clientConfig, new AcceptAllClientInteraction());
 
 				//Overrides client fee
 				((RPCFeeService)ClientRuntime.Services.FeeService).FallBackFeeRate = new FeeRate(Money.Satoshis(50), 1);

--- a/NTumbleBit.Tests/TumblerServerTester.cs
+++ b/NTumbleBit.Tests/TumblerServerTester.cs
@@ -121,7 +121,7 @@ namespace NTumbleBit.Tests
 
 			    RPCClient rpcClient =  clientConfig.RPCArgs.ConfigureRPCClient(clientConfig.Network);			    
 			    clientConfig.Services = ExternalServices.CreateFromRPCClient(rpcClient, clientConfig.DBreezeRepository, clientConfig.Tracker);
-
+                clientConfig.DestinationWallet = new ClientDestinationWallet(clientConfig.OutputWallet.RootKey, clientConfig.OutputWallet.KeyPath, clientConfig.DBreezeRepository, clientConfig.Network);
                 ClientRuntime = TumblerClientRuntime.FromConfiguration(clientConfig, new AcceptAllClientInteraction());
 
 				//Overrides client fee

--- a/NTumbleBit.Tests/TumblerServerTester.cs
+++ b/NTumbleBit.Tests/TumblerServerTester.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Server.Kestrel;
 using NBitcoin;
+using NBitcoin.RPC;
 using NTumbleBit.ClassicTumbler;
 using NTumbleBit.ClassicTumbler.CLI;
 using NTumbleBit.ClassicTumbler.Client;
@@ -17,6 +18,8 @@ using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using NTumbleBit.Services;
+using NTumbleBit.Configuration;
 
 namespace NTumbleBit.Tests
 {
@@ -63,7 +66,8 @@ namespace NTumbleBit.Tests
 				
 				var conf = new TumblerConfiguration();
 				conf.DataDir = Path.Combine(directory, "server");
-				Directory.CreateDirectory(conf.DataDir);
+
+                Directory.CreateDirectory(conf.DataDir);
 				File.WriteAllBytes(Path.Combine(conf.DataDir, "Tumbler.pem"), TestKeys.Default.ToBytes());
 				File.WriteAllBytes(Path.Combine(conf.DataDir, "Voucher.pem"), TestKeys.Default2.ToBytes());
 				conf.RPC.Url = TumblerNode.CreateRPCClient().Address;
@@ -73,13 +77,19 @@ namespace NTumbleBit.Tests
 				conf.Network = Network.RegTest;
 				conf.Listen = new System.Net.IPEndPoint(IPAddress.Parse("127.0.0.1"), 5000);
 				conf.AllowInsecure = true;
-				conf.ClassicTumblerParameters.FakePuzzleCount /= 4;
+			    conf.DBreezeRepository = new DBreezeRepository(Path.Combine(conf.DataDir, "db2"));
+			    conf.Tracker = new Tracker(conf.DBreezeRepository, conf.Network);
+
+                conf.ClassicTumblerParameters.FakePuzzleCount /= 4;
 				conf.ClassicTumblerParameters.FakeTransactionCount /= 4;
 				conf.ClassicTumblerParameters.RealTransactionCount /= 4;
 				conf.ClassicTumblerParameters.RealPuzzleCount /= 4;
 				conf.ClassicTumblerParameters.CycleGenerator.FirstCycle.Start = 105;
 
-				var runtime = TumblerRuntime.FromConfiguration(conf, new AcceptAllClientInteraction());
+			    RPCClient rpc =  conf.RPC.ConfigureRPCClient(conf.Network);
+			    conf.Services = ExternalServices.CreateFromRPCClient(rpc, conf.DBreezeRepository, conf.Tracker);
+
+                var runtime = TumblerRuntime.FromConfiguration(conf, new AcceptAllClientInteraction());
 				_Host = new WebHostBuilder()
 					.UseAppConfiguration(runtime)
 					.UseContentRoot(Path.GetFullPath(directory))
@@ -105,9 +115,14 @@ namespace NTumbleBit.Tests
 				creds = ExtractCredentials(File.ReadAllText(AliceNode.Config));
 				clientConfig.RPCArgs.User = creds.Item1;
 				clientConfig.RPCArgs.Password = creds.Item2;
-				clientConfig.TumblerServer = runtime.TumblerUris.First();
+			    clientConfig.DBreezeRepository = new DBreezeRepository(Path.Combine(clientConfig.DataDir, "db2"));
+			    clientConfig.Tracker = new Tracker(clientConfig.DBreezeRepository, clientConfig.Network);
+                clientConfig.TumblerServer = runtime.TumblerUris.First();
 
-				ClientRuntime = TumblerClientRuntime.FromConfiguration(clientConfig, new AcceptAllClientInteraction());
+			    RPCClient rpcClient =  clientConfig.RPCArgs.ConfigureRPCClient(clientConfig.Network);			    
+			    clientConfig.Services = ExternalServices.CreateFromRPCClient(rpcClient, clientConfig.DBreezeRepository, clientConfig.Tracker);
+
+                ClientRuntime = TumblerClientRuntime.FromConfiguration(clientConfig, new AcceptAllClientInteraction());
 
 				//Overrides client fee
 				((RPCFeeService)ClientRuntime.Services.FeeService).FallBackFeeRate = new FeeRate(Money.Satoshis(50), 1);

--- a/NTumbleBit/ClassicTumbler/CLI/ClientInteractiveRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/CLI/ClientInteractiveRuntime.cs
@@ -29,7 +29,7 @@ namespace NTumbleBit.ClassicTumbler.CLI
 
 		public Tracker Tracker => InnerRuntime.Tracker;
 
-		public ExternalServices Services => InnerRuntime.Services;
+		public IExternalServices Services => InnerRuntime.Services;
 
 		public IDestinationWallet DestinationWallet => InnerRuntime.DestinationWallet;
 

--- a/NTumbleBit/ClassicTumbler/CLI/IInteractiveRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/CLI/IInteractiveRuntime.cs
@@ -22,7 +22,7 @@ namespace NTumbleBit.ClassicTumbler.CLI
 		{
 			get;
 		}
-		ExternalServices Services
+		IExternalServices Services
 		{
 			get;
 		}

--- a/NTumbleBit/ClassicTumbler/CLI/ServerInteractiveRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/CLI/ServerInteractiveRuntime.cs
@@ -28,7 +28,7 @@ namespace NTumbleBit.ClassicTumbler.CLI
 
 		public Tracker Tracker => InnerRuntime.Tracker;
 
-		public ExternalServices Services => InnerRuntime.Services;
+		public IExternalServices Services => InnerRuntime.Services;
 
 		public IDestinationWallet DestinationWallet => null;
 

--- a/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
+++ b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
@@ -62,7 +62,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 				return Runtime.Tracker;
 			}
 		}
-		public ExternalServices Services
+		public IExternalServices Services
 		{
 			get
 			{

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientConfiguration.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientConfiguration.cs
@@ -43,7 +43,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			get; set;
 		} = new RPCArgs();
 
-	    public TumblerClientConfiguration LoadArgs(String[] args)
+		public TumblerClientConfiguration LoadArgs(String[] args)
 		{
 			ConfigurationFile = args.Where(a => a.StartsWith("-conf=", StringComparison.Ordinal)).Select(a => a.Substring("-conf=".Length).Replace("\"", "")).FirstOrDefault();
 			DataDir = args.Where(a => a.StartsWith("-datadir=", StringComparison.Ordinal)).Select(a => a.Substring("-datadir=".Length).Replace("\"", "")).FirstOrDefault();
@@ -139,37 +139,37 @@ namespace NTumbleBit.ClassicTumbler.Client
 
 			AllowInsecure = config.GetOrDefault<bool>("allowinsecure", IsTest(Network));
 
-		    RPCClient rpc = null;
-		    try
-		    {
-		        rpc = RPCArgs.ConfigureRPCClient(Network);
-		    }
-		    catch
-		    {
-		        throw new ConfigException("Please, fix rpc settings in " + ConfigurationFile);
-		    }
+			RPCClient rpc = null;
+			try
+			{
+				rpc = RPCArgs.ConfigureRPCClient(Network);
+			}
+			catch
+			{
+				throw new ConfigException("Please, fix rpc settings in " + ConfigurationFile);
+			}
 
-		    DBreezeRepository = new DBreezeRepository(Path.Combine(DataDir, "db2"));
-		    Tracker = new Tracker(DBreezeRepository, Network);
-		    Services = ExternalServices.CreateFromRPCClient(rpc, DBreezeRepository, Tracker);
+			DBreezeRepository = new DBreezeRepository(Path.Combine(DataDir, "db2"));
+			Tracker = new Tracker(DBreezeRepository, Network);
+			Services = ExternalServices.CreateFromRPCClient(rpc, DBreezeRepository, Tracker);
 
-		    if (OutputWallet.RootKey != null && OutputWallet.KeyPath != null)
-		        DestinationWallet = new ClientDestinationWallet(OutputWallet.RootKey, OutputWallet.KeyPath, DBreezeRepository, Network);
-		    else if (OutputWallet.RPCArgs != null)
-		    {
-		        try
-		        {
-		            DestinationWallet = new RPCDestinationWallet(OutputWallet.RPCArgs.ConfigureRPCClient(Network));
-		        }
-		        catch
-		        {
-		            throw new ConfigException("Please, fix outputwallet rpc settings in " + ConfigurationFile);
-		        }
-		    }
-		    else
-		        throw new ConfigException("Missing configuration for outputwallet");
+			if (OutputWallet.RootKey != null && OutputWallet.KeyPath != null)
+				DestinationWallet = new ClientDestinationWallet(OutputWallet.RootKey, OutputWallet.KeyPath, DBreezeRepository, Network);
+			else if (OutputWallet.RPCArgs != null)
+			{
+				try
+				{
+					DestinationWallet = new RPCDestinationWallet(OutputWallet.RPCArgs.ConfigureRPCClient(Network));
+				}
+				catch
+				{
+					throw new ConfigException("Please, fix outputwallet rpc settings in " + ConfigurationFile);
+				}
+			}
+			else
+				throw new ConfigException("Missing configuration for outputwallet");
 
-            return this;
+			return this;
 		}
 
 		public static string GetDefaultConfigurationFile(string dataDirectory, Network network)

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientConfiguration.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientConfiguration.cs
@@ -30,95 +30,20 @@ namespace NTumbleBit.ClassicTumbler.Client
 		}
 	}
 
-	public class TumblerClientConfiguration
+	public class TumblerClientConfiguration : TumblerClientConfigurationBase
 	{
 		public string ConfigurationFile
 		{
 			get;
 			set;
 		}
-		public string DataDir
-		{
-			get;
-			set;
-		}
-
-		public Network Network
-		{
-			get; set;
-		}
-
-		public bool OnlyMonitor
-		{
-			get; set;
-		}
-
-		public bool CheckIp
-		{
-			get; set;
-		} = true;
-
-		public bool Cooperative
-		{
-			get;
-			set;
-		}
-		public TumblerUrlBuilder TumblerServer
-		{
-			get;
-			set;
-		}
-
-		public ConnectionSettingsBase BobConnectionSettings
-		{
-			get; set;
-		} = new ConnectionSettingsBase();
-
-		public ConnectionSettingsBase AliceConnectionSettings
-		{
-			get; set;
-		} = new ConnectionSettings.ConnectionSettingsBase();
-
-		public OutputWalletConfiguration OutputWallet
-		{
-			get; set;
-		} = new OutputWalletConfiguration();
 
 		public RPCArgs RPCArgs
 		{
 			get; set;
 		} = new RPCArgs();
-		public bool AllowInsecure
-		{
-			get;
-			set;
-		} = false;
-		public string TorPath
-		{
-			get;
-			set;
-		}
 
-	    public Tracker Tracker
-	    {
-	        get;
-	        set;
-	    }
-
-        public ExternalServices Services
-	    {
-	        get;
-	        set;
-	    }
-
-	    public DBreezeRepository DBreezeRepository
-	    {
-	        get;
-	        set;
-	    }
-
-
-        public TumblerClientConfiguration LoadArgs(String[] args)
+	    public TumblerClientConfiguration LoadArgs(String[] args)
 		{
 			ConfigurationFile = args.Where(a => a.StartsWith("-conf=", StringComparison.Ordinal)).Select(a => a.Substring("-conf=".Length).Replace("\"", "")).FirstOrDefault();
 			DataDir = args.Where(a => a.StartsWith("-datadir=", StringComparison.Ordinal)).Select(a => a.Substring("-datadir=".Length).Replace("\"", "")).FirstOrDefault();
@@ -228,12 +153,23 @@ namespace NTumbleBit.ClassicTumbler.Client
 		    Tracker = new Tracker(DBreezeRepository, Network);
 		    Services = ExternalServices.CreateFromRPCClient(rpc, DBreezeRepository, Tracker);
 
-            return this;
-		}
+		    if (OutputWallet.RootKey != null && OutputWallet.KeyPath != null)
+		        DestinationWallet = new ClientDestinationWallet(OutputWallet.RootKey, OutputWallet.KeyPath, DBreezeRepository, Network);
+		    else if (OutputWallet.RPCArgs != null)
+		    {
+		        try
+		        {
+		            DestinationWallet = new RPCDestinationWallet(OutputWallet.RPCArgs.ConfigureRPCClient(Network));
+		        }
+		        catch
+		        {
+		            throw new ConfigException("Please, fix outputwallet rpc settings in " + ConfigurationFile);
+		        }
+		    }
+		    else
+		        throw new ConfigException("Missing configuration for outputwallet");
 
-		private bool IsTest(Network network)
-		{
-			return network == Network.TestNet || network == Network.RegTest;
+            return this;
 		}
 
 		public static string GetDefaultConfigurationFile(string dataDirectory, Network network)
@@ -313,7 +249,6 @@ namespace NTumbleBit.ClassicTumbler.Client
 		{
 			if(!File.Exists(ConfigurationFile))
 				throw new ConfigurationException("Configuration file does not exists");
-		}
-
+		}	   
 	}
 }

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientConfigurationBase.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientConfigurationBase.cs
@@ -1,0 +1,96 @@
+﻿using NTumbleBit.ClassicTumbler.Client.ConnectionSettings;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using NBitcoin;
+using NTumbleBit.Services;
+
+namespace NTumbleBit.ClassicTumbler.Client
+{
+	public abstract class TumblerClientConfigurationBase
+	{               
+		public string DataDir
+		{
+			get;
+			set;
+		}
+
+		public Network Network
+		{
+			get; set;
+		}
+
+		public bool OnlyMonitor
+		{
+			get; set;
+		}
+
+		public bool CheckIp
+		{
+			get; set;
+		} = true;
+
+		public bool Cooperative
+		{
+			get;
+			set;
+		}
+		public TumblerUrlBuilder TumblerServer
+		{
+			get;
+			set;
+		}
+
+		public ConnectionSettingsBase BobConnectionSettings
+		{
+			get; set;
+		} = new ConnectionSettingsBase();
+
+		public ConnectionSettingsBase AliceConnectionSettings
+		{
+			get; set;
+		} = new ConnectionSettings.ConnectionSettingsBase();
+
+		public OutputWalletConfiguration OutputWallet
+		{
+			get; set;
+		} = new OutputWalletConfiguration();
+
+		public bool AllowInsecure
+		{
+			get;
+			set;
+		} = false;
+
+		public string TorPath
+		{
+			get;
+			set;
+		}
+
+		public Tracker Tracker
+		{
+			get;
+			set;
+		}
+
+		public DBreezeRepository DBreezeRepository
+		{
+			get;
+			set;
+		}
+
+		public IExternalServices Services
+		{
+			get;
+			set;
+		}
+
+		protected bool IsTest(Network network)
+		{
+			return network == Network.TestNet || network == Network.RegTest;
+		}
+
+		public IDestinationWallet DestinationWallet { get; set; }
+	}
+}

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientConfigurationBase.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientConfigurationBase.cs
@@ -8,7 +8,7 @@ using NTumbleBit.Services;
 namespace NTumbleBit.ClassicTumbler.Client
 {
 	public abstract class TumblerClientConfigurationBase
-	{               
+	{
 		public string DataDir
 		{
 			get;

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
@@ -60,9 +60,9 @@ namespace NTumbleBit.ClassicTumbler.Client
 			Cooperative = configuration.Cooperative;
 			Repository = configuration.DBreezeRepository;
 			_Disposables.Add(Repository);
-		    Tracker = configuration.Tracker;
+			Tracker = configuration.Tracker;
 			Services = configuration.Services;
-		    DestinationWallet = configuration.DestinationWallet;
+			DestinationWallet = configuration.DestinationWallet;
 			TumblerParameters = Repository.Get<ClassicTumbler.ClassicTumblerParameters>("Configuration", configuration.TumblerServer.Uri.AbsoluteUri);
 
 			if(TumblerParameters != null && TumblerParameters.GetHash() != configuration.TumblerServer.ConfigurationHash)

--- a/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Client/TumblerClientRuntime.cs
@@ -26,12 +26,12 @@ namespace NTumbleBit.ClassicTumbler.Client
 
 	public class TumblerClientRuntime : IDisposable
 	{
-		public static TumblerClientRuntime FromConfiguration(TumblerClientConfiguration configuration, ClientInteraction interaction)
+		public static TumblerClientRuntime FromConfiguration(TumblerClientConfigurationBase configuration, ClientInteraction interaction)
 		{
 			return FromConfigurationAsync(configuration, interaction).GetAwaiter().GetResult();
 		}
 
-		public static async Task<TumblerClientRuntime> FromConfigurationAsync(TumblerClientConfiguration configuration, ClientInteraction interaction)
+		public static async Task<TumblerClientRuntime> FromConfigurationAsync(TumblerClientConfigurationBase configuration, ClientInteraction interaction)
 		{
 			TumblerClientRuntime runtime = new TumblerClientRuntime();
 			try
@@ -45,7 +45,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			}
 			return runtime;
 		}
-		public async Task ConfigureAsync(TumblerClientConfiguration configuration, ClientInteraction interaction)
+		public async Task ConfigureAsync(TumblerClientConfigurationBase configuration, ClientInteraction interaction)
 		{
 			interaction = interaction ?? new AcceptAllClientInteraction();
 
@@ -62,23 +62,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			_Disposables.Add(Repository);
 		    Tracker = configuration.Tracker;
 			Services = configuration.Services;
-
-			if(configuration.OutputWallet.RootKey != null && configuration.OutputWallet.KeyPath != null)
-				DestinationWallet = new ClientDestinationWallet(configuration.OutputWallet.RootKey, configuration.OutputWallet.KeyPath, Repository, configuration.Network);
-			else if(configuration.OutputWallet.RPCArgs != null)
-			{
-				try
-				{
-					DestinationWallet = new RPCDestinationWallet(configuration.OutputWallet.RPCArgs.ConfigureRPCClient(Network));
-				}
-				catch
-				{
-					throw new ConfigException("Please, fix outputwallet rpc settings in " + configuration.ConfigurationFile);
-				}
-			}
-			else
-				throw new ConfigException("Missing configuration for outputwallet");
-
+		    DestinationWallet = configuration.DestinationWallet;
 			TumblerParameters = Repository.Get<ClassicTumbler.ClassicTumblerParameters>("Configuration", configuration.TumblerServer.Uri.AbsoluteUri);
 
 			if(TumblerParameters != null && TumblerParameters.GetHash() != configuration.TumblerServer.ConfigurationHash)
@@ -224,7 +208,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			get;
 			set;
 		}
-		public ExternalServices Services
+		public IExternalServices Services
 		{
 			get;
 			set;

--- a/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
@@ -82,25 +82,25 @@ namespace NTumbleBit.ClassicTumbler.Server
 			set;
 		}
 
-	    public Tracker Tracker
-	    {
-	        get;
-	        set;
-	    }
+		public Tracker Tracker
+		{
+			get;
+			set;
+		}
 
-	    public ExternalServices Services
-	    {
-	        get;
-	        set;
-	    }
+		public ExternalServices Services
+		{
+			get;
+			set;
+		}
 
-	    public DBreezeRepository DBreezeRepository
-	    {
-	        get;
-	        set;
-	    }
+		public DBreezeRepository DBreezeRepository
+		{
+			get;
+			set;
+		}
 
-        public TumblerConfiguration LoadArgs(String[] args)
+		public TumblerConfiguration LoadArgs(String[] args)
 		{
 			ConfigurationFile = args.Where(a => a.StartsWith("-conf=", StringComparison.Ordinal)).Select(a => a.Substring("-conf=".Length).Replace("\"", "")).FirstOrDefault();
 			DataDir = args.Where(a => a.StartsWith("-datadir=", StringComparison.Ordinal)).Select(a => a.Substring("-datadir=".Length).Replace("\"", "")).FirstOrDefault();
@@ -176,21 +176,21 @@ namespace NTumbleBit.ClassicTumbler.Server
 
 			RPC = RPCArgs.Parse(config, Network);
 			TorPath = config.GetOrDefault<string>("torpath", "tor");		    
-		    DBreezeRepository = new DBreezeRepository(Path.Combine(DataDir, "db2"));
-		    Tracker = new Tracker(DBreezeRepository, Network);
+			DBreezeRepository = new DBreezeRepository(Path.Combine(DataDir, "db2"));
+			Tracker = new Tracker(DBreezeRepository, Network);
 
-		    RPCClient rpc = null;
-		    try
-		    {
-		        rpc = RPC.ConfigureRPCClient(Network);
-		    }
-		    catch
-		    {
-		        throw new ConfigException("Please, fix rpc settings in " + ConfigurationFile);
-		    }
+			RPCClient rpc = null;
+			try
+			{
+				rpc = RPC.ConfigureRPCClient(Network);
+			}
+			catch
+			{
+				throw new ConfigException("Please, fix rpc settings in " + ConfigurationFile);
+			}
 
-            Services = ExternalServices.CreateFromRPCClient(rpc, DBreezeRepository, Tracker);
-            return this;
+			Services = ExternalServices.CreateFromRPCClient(rpc, DBreezeRepository, Tracker);
+			return this;
 		}
 
 		public string CycleName

--- a/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using NBitcoin;
 using System;
 using System.IO;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using NTumbleBit.Logging;
@@ -11,6 +10,8 @@ using System.Runtime.InteropServices;
 using NTumbleBit.Configuration;
 using System.Diagnostics;
 using NTumbleBit.ClassicTumbler.Client.ConnectionSettings;
+using NTumbleBit.Services;
+using NBitcoin.RPC;
 
 namespace NTumbleBit.ClassicTumbler.Server
 {
@@ -81,7 +82,25 @@ namespace NTumbleBit.ClassicTumbler.Server
 			set;
 		}
 
-		public TumblerConfiguration LoadArgs(String[] args)
+	    public Tracker Tracker
+	    {
+	        get;
+	        set;
+	    }
+
+	    public ExternalServices Services
+	    {
+	        get;
+	        set;
+	    }
+
+	    public DBreezeRepository DBreezeRepository
+	    {
+	        get;
+	        set;
+	    }
+
+        public TumblerConfiguration LoadArgs(String[] args)
 		{
 			ConfigurationFile = args.Where(a => a.StartsWith("-conf=", StringComparison.Ordinal)).Select(a => a.Substring("-conf=".Length).Replace("\"", "")).FirstOrDefault();
 			DataDir = args.Where(a => a.StartsWith("-datadir=", StringComparison.Ordinal)).Select(a => a.Substring("-datadir=".Length).Replace("\"", "")).FirstOrDefault();
@@ -156,8 +175,22 @@ namespace NTumbleBit.ClassicTumbler.Server
 			Listen = new IPEndPoint(IPAddress.Parse("127.0.0.1"), defaultPort);
 
 			RPC = RPCArgs.Parse(config, Network);
-			TorPath = config.GetOrDefault<string>("torpath", "tor");
-			return this;
+			TorPath = config.GetOrDefault<string>("torpath", "tor");		    
+		    DBreezeRepository = new DBreezeRepository(Path.Combine(DataDir, "db2"));
+		    Tracker = new Tracker(DBreezeRepository, Network);
+
+		    RPCClient rpc = null;
+		    try
+		    {
+		        rpc = RPC.ConfigureRPCClient(Network);
+		    }
+		    catch
+		    {
+		        throw new ConfigException("Please, fix rpc settings in " + ConfigurationFile);
+		    }
+
+            Services = ExternalServices.CreateFromRPCClient(rpc, DBreezeRepository, Tracker);
+            return this;
 		}
 
 		public string CycleName

--- a/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
@@ -1,20 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using NBitcoin.RPC;
 using System.IO;
 using NTumbleBit.Logging;
 using NTumbleBit.Services;
-using NTumbleBit.ClassicTumbler;
 using NBitcoin;
 using NTumbleBit.Configuration;
-using NTumbleBit.ClassicTumbler.Client;
 using NTumbleBit.ClassicTumbler.CLI;
 using System.Text;
 using System.Net;
-using System.Threading;
 using NTumbleBit.Tor;
 
 namespace NTumbleBit.ClassicTumbler.Server
@@ -51,16 +46,7 @@ namespace NTumbleBit.ClassicTumbler.Server
 			ClassicTumblerParameters = conf.ClassicTumblerParameters.Clone();
 			Network = conf.Network;
 			LocalEndpoint = conf.Listen;
-			RPCClient rpcClient = null;
-			try
-			{
-				rpcClient = conf.RPC.ConfigureRPCClient(conf.Network);
-			}
-			catch
-			{
-				throw new ConfigException("Please, fix rpc settings in " + conf.ConfigurationFile);
-			}
-
+			
 			bool torConfigured = false;
 			if(conf.TorSettings != null)
 			{
@@ -170,12 +156,11 @@ namespace NTumbleBit.ClassicTumbler.Server
 			}
 			Logs.Configuration.LogInformation($"--------------------------------");
 			Logs.Configuration.LogInformation("");
-
-			var dbreeze = new DBreezeRepository(Path.Combine(conf.DataDir, "db2"));
-			Repository = dbreeze;
-			_Resources.Add(dbreeze);
-			Tracker = new Tracker(dbreeze, Network);
-			Services = ExternalServices.CreateFromRPCClient(rpcClient, dbreeze, Tracker);
+			
+			Repository = conf.DBreezeRepository;
+			_Resources.Add(Repository);
+			Tracker = conf.Tracker;
+			Services = conf.Services;
 		}
 
 		public Uri TorUri
@@ -227,7 +212,7 @@ namespace NTumbleBit.ClassicTumbler.Server
 			get;
 			set;
 		}
-		public IRepository Repository
+		public DBreezeRepository Repository
 		{
 			get;
 			set;

--- a/NTumbleBit/Services/BroadcasterJob.cs
+++ b/NTumbleBit/Services/BroadcasterJob.cs
@@ -12,7 +12,7 @@ namespace NTumbleBit.Services
 {
 	public class BroadcasterJob : TumblerServiceBase
 	{
-		public BroadcasterJob(ExternalServices services)
+		public BroadcasterJob(IExternalServices services)
 		{
 			BroadcasterService = services.BroadcastService;
 			TrustedBroadcasterService = services.TrustedBroadcastService;

--- a/NTumbleBit/Services/ExternalServices.cs
+++ b/NTumbleBit/Services/ExternalServices.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NTumbleBit.Services
 {
-	public class ExternalServices
+	public class ExternalServices : IExternalServices
     {
 		public static ExternalServices CreateFromRPCClient(RPCClient rpc, IRepository repository, Tracker tracker)
 		{

--- a/NTumbleBit/Services/IExternalServices.cs
+++ b/NTumbleBit/Services/IExternalServices.cs
@@ -1,0 +1,19 @@
+﻿
+namespace NTumbleBit.Services
+{
+    /// <summary>
+    /// Interface containing objects used for interacting with a bitcoin node.
+    /// </summary>
+    public interface IExternalServices
+    {        
+        IFeeService FeeService { get; set; }
+    
+        IWalletService WalletService { get; set; }
+
+        IBroadcastService BroadcastService { get; set; }
+        
+        IBlockExplorerService BlockExplorerService { get; set; }
+        
+        ITrustedBroadcastService TrustedBroadcastService { get; set; }
+    }
+}

--- a/NTumbleBit/Services/IExternalServices.cs
+++ b/NTumbleBit/Services/IExternalServices.cs
@@ -1,19 +1,19 @@
 ﻿
 namespace NTumbleBit.Services
 {
-    /// <summary>
-    /// Interface containing objects used for interacting with a bitcoin node.
-    /// </summary>
-    public interface IExternalServices
-    {        
-        IFeeService FeeService { get; set; }
-    
-        IWalletService WalletService { get; set; }
+	/// <summary>
+	/// Interface containing objects used for interacting with a bitcoin node.
+	/// </summary>
+	public interface IExternalServices
+	{        
+		IFeeService FeeService { get; set; }
+	
+		IWalletService WalletService { get; set; }
 
-        IBroadcastService BroadcastService { get; set; }
-        
-        IBlockExplorerService BlockExplorerService { get; set; }
-        
-        ITrustedBroadcastService TrustedBroadcastService { get; set; }
-    }
+		IBroadcastService BroadcastService { get; set; }
+		
+		IBlockExplorerService BlockExplorerService { get; set; }
+		
+		ITrustedBroadcastService TrustedBroadcastService { get; set; }
+	}
 }


### PR DESCRIPTION
I created parent classes for ExternalServices and TumblerClientConfiguration so that a custom config can be used with the TumblerClientRuntime, without having any dependency on RPC or any configuration file.
This will be particularly useful for the Breeze Client as it doesn't have access to a Bitcoin Core node and won't be using a configuration file to initialize the runtime.
Tests are passing :-)
