### PR TITLE
Reapplied commits to BigInteger.cs after adding the newer version 

### DIFF
--- a/NTumbleBit/BouncyCastle/crypto/generators/RsaKeyPairGenerator.cs
+++ b/NTumbleBit/BouncyCastle/crypto/generators/RsaKeyPairGenerator.cs
@@ -1,7 +1,4 @@
-﻿using System;
-
-using NTumbleBit.BouncyCastle.Crypto;
-using NTumbleBit.BouncyCastle.Crypto.Parameters;
+﻿using NTumbleBit.BouncyCastle.Crypto.Parameters;
 using NTumbleBit.BouncyCastle.Math;
 using NTumbleBit.BouncyCastle.Utilities;
 
@@ -108,7 +105,6 @@ namespace NTumbleBit.BouncyCastle.Crypto.Generators
 
 				BigInteger pSub1 = p.Subtract(One);
 				BigInteger qSub1 = q.Subtract(One);
-				//BigInteger phi = pSub1.Multiply(qSub1);
 				BigInteger gcd = pSub1.Gcd(qSub1);
 				BigInteger lcm = pSub1.Divide(gcd).Multiply(qSub1);
 

--- a/NTumbleBit/BouncyCastle/math/BigInteger.cs
+++ b/NTumbleBit/BouncyCastle/math/BigInteger.cs
@@ -153,7 +153,7 @@ namespace NTumbleBit.BouncyCastle.Math
 		//    4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8
 		//};
 
-		private readonly static byte[] BitLengthTable =
+		private static readonly byte[] BitLengthTable =
 		{
 			0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4,
 			5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,

--- a/NTumbleBit/BouncyCastle/math/BigInteger.cs
+++ b/NTumbleBit/BouncyCastle/math/BigInteger.cs
@@ -1256,7 +1256,6 @@ namespace NTumbleBit.BouncyCastle.Math
 
 		private bool IsEqualMagnitude(BigInteger x)
 		{
-			int[] xMag = x.magnitude;
 			if(magnitude.Length != x.magnitude.Length)
 				return false;
 			for(int i = 0; i < magnitude.Length; i++)

--- a/NTumbleBit/BouncyCastle/math/BigInteger.cs
+++ b/NTumbleBit/BouncyCastle/math/BigInteger.cs
@@ -233,8 +233,8 @@ namespace NTumbleBit.BouncyCastle.Math
 			}
 		}
 
-		private int[] magnitude; // array of ints with [0] being the most significant
-		private int sign; // -1 means -ve; +1 means +ve; 0 means 0;
+		private readonly int[] magnitude; // array of ints with [0] being the most significant
+		private readonly int sign; // -1 means -ve; +1 means +ve; 0 means 0;
 		private int nBits = -1; // cache BitCount() value
 		private int nBitLength = -1; // cache BitLength() value
 		private int mQuote = 0; // -m^(-1) mod b, b = 2^32 (see Montgomery mult.), 0 when uninitialised

--- a/NTumbleBit/BouncyCastle/math/BigInteger.cs
+++ b/NTumbleBit/BouncyCastle/math/BigInteger.cs
@@ -2459,7 +2459,7 @@ namespace NTumbleBit.BouncyCastle.Math
 		public BigInteger Multiply(
 			BigInteger val)
 		{
-			if(val == this)
+			if(Equals(val, this))
 				return Square();
 
 			if((sign & val.sign) == 0)

--- a/NTumbleBit/BouncyCastle/math/BigInteger.cs
+++ b/NTumbleBit/BouncyCastle/math/BigInteger.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
-
 using NTumbleBit.BouncyCastle.Security;
 using NTumbleBit.BouncyCastle.Utilities;
 


### PR DESCRIPTION
After adding the newer version of BigInteger.cs (#87), some commits that @nopara73 added to the file were overwritten ([here](https://github.com/NTumbleBit/NTumbleBit/commits/999bb2d3ae954095dff8ee65e1db8749792e4184/NTumbleBit/BouncyCastle/math/BigInteger.cs)). I just reapplied them to the file and removed some unused namespaces from RsaKeyPairGenerator.cs.