### PR TITLE
Change logging Timestamps to 24hr format

### DIFF
--- a/NTumbleBit/Logging/ConsoleLogger.cs
+++ b/NTumbleBit/Logging/ConsoleLogger.cs
@@ -357,7 +357,7 @@ namespace NTumbleBit.Logging
 		// for testing
 		internal virtual void WriteMessage(LogMessageEntry message)
 		{
-			var dateTime = $"[{DateTimeOffset.Now.ToString("yy-MM-dd hh:mm:ss")}] ";
+			var dateTime = $"[{DateTimeOffset.Now.ToString("yy-MM-dd HH:mm:ss")}] ";
 			Console.Write(dateTime, message.MessageColor, message.MessageColor);
 			if(message.LevelString != null)
 			{


### PR DESCRIPTION
Convert timestamps to 24hr format, for easier reading/tracking of events of program outputs, as it was confusing if it was AM or PM without having to scroll back in the events to determine the part of day.