### PR TITLE
update PermutationTest and PoupardStern

### DIFF
--- a/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
+++ b/NTumbleBit/ClassicTumbler/Server/TumblerRuntime.cs
@@ -1,26 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
 using NBitcoin.RPC;
-using System.IO;
+using NTumbleBit.ClassicTumbler.CLI;
+using NTumbleBit.Configuration;
 using NTumbleBit.Logging;
 using NTumbleBit.Services;
-using NTumbleBit.ClassicTumbler;
-using NBitcoin;
-using NTumbleBit.Configuration;
-using NTumbleBit.ClassicTumbler.Client;
-using NTumbleBit.ClassicTumbler.CLI;
-using System.Text;
-using System.Net;
-using System.Threading;
 using NTumbleBit.Tor;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
 using TumbleBitSetup;
 
 namespace NTumbleBit.ClassicTumbler.Server
 {
-	public class TumblerRuntime : IDisposable
+    public class TumblerRuntime : IDisposable
 	{
 		public static TumblerRuntime FromConfiguration(TumblerConfiguration conf, ClientInteraction interaction)
 		{
@@ -89,10 +85,12 @@ namespace NTumbleBit.ClassicTumbler.Server
 						Logs.Configuration.LogWarning($"Tor RSA private key generated to {torRSA}");
 					}
 
-					var tumblerUri = new TumblerUrlBuilder();
-					tumblerUri.Port = result.HiddenServiceUri.Port;
-					tumblerUri.Host = result.HiddenServiceUri.Host;
-					TumblerUris.Add(tumblerUri);
+                    var tumblerUri = new TumblerUrlBuilder
+                    {
+                        Port = result.HiddenServiceUri.Port,
+                        Host = result.HiddenServiceUri.Host
+                    };
+                    TumblerUris.Add(tumblerUri);
 					TorUri = tumblerUri.GetRoutableUri(false);
 					ClassicTumblerParameters.ExpectedAddress = TorUri.AbsoluteUri;
 					Logs.Configuration.LogInformation($"Tor configured on {result.HiddenServiceUri}");

--- a/NTumbleBit/Proof/PermutationTest/PermutationTestProof.cs
+++ b/NTumbleBit/Proof/PermutationTest/PermutationTestProof.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TumbleBitSetup
 {

--- a/NTumbleBit/Proof/PermutationTest/PermutationTestSetup.cs
+++ b/NTumbleBit/Proof/PermutationTest/PermutationTestSetup.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TumbleBitSetup
 {

--- a/NTumbleBit/Proof/PoupardStern/PoupardSternProof.cs
+++ b/NTumbleBit/Proof/PoupardStern/PoupardSternProof.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using NTumbleBit.BouncyCastle.Math;
+﻿using NTumbleBit.BouncyCastle.Math;
+using System;
 
 namespace TumbleBitSetup
 {

--- a/NTumbleBit/Proof/PoupardStern/PoupardSternSetup.cs
+++ b/NTumbleBit/Proof/PoupardStern/PoupardSternSetup.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TumbleBitSetup
 {


### PR DESCRIPTION
Sharon (@goldbe) and I updated the setup protocol to include additional validation checks ([more info](https://github.com/osagga/TumbleBitSetup/pull/25)) to the proving functions (PoupardStern and PermutationTest) such that we can rule out invalid RSA keys before generating the proof. 

This update is based on the fact that RsaKeyParameters.cs ([here](https://github.com/NTumbleBit/NTumbleBit/blob/master/NTumbleBit/BouncyCastle/crypto/parameters/RsaKeyParameters.cs#L29)) is missing some extra validation checks on the Modulus (such as is N is even, and if N has a small prime factor) from the original RsaKeyParameters.cs in the BoucyCastle library [here](https://github.com/bcgit/bc-csharp/commit/c8354a4635bc66c4878eca13b0c0ebc9da266839) (similar to what happened in #87).

Now given how the proving function would throw exceptions when handling bad RSA keys, it is recommend to generate proofs in the following way:
```
while(true){
  Try{
    key = new RSAkey(~);
    proof = Prove(key);
  }catch(Exception){
    Continue;
  }
  Break;
}
```