### PR TITLE
Typo fix and use of nameof()

### DIFF
--- a/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
+++ b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
@@ -1,21 +1,16 @@
-﻿using NTumbleBit.ClassicTumbler;
-using NTumbleBit;
-using NTumbleBit.PuzzleSolver;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using Microsoft.Extensions.Logging;
 using NBitcoin;
-using NTumbleBit.PuzzlePromise;
-using Microsoft.Extensions.Logging;
-using NTumbleBit.Logging;
-using NTumbleBit.Services;
-using Microsoft.Extensions.Logging.Abstractions;
 using NTumbleBit.ClassicTumbler.Server.Models;
+using NTumbleBit.Logging;
+using NTumbleBit.PuzzlePromise;
+using NTumbleBit.PuzzleSolver;
+using NTumbleBit.Services;
+using System;
+using System.Linq;
 
 namespace NTumbleBit.ClassicTumbler.Client
 {
-	public enum PaymentStateMachineStatus
+    public enum PaymentStateMachineStatus
 	{
 		New,
 		Registered,
@@ -46,7 +41,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			TumblerClientRuntime runtime)
 		{
 			if(runtime == null)
-				throw new ArgumentNullException("runtime");
+				throw new ArgumentNullException(nameof(runtime));
 			Runtime = runtime;
 		}
 
@@ -359,7 +354,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 
 							if(tumblerEscrow.OutputIndex >= tumblerEscrow.Transaction.Outputs.Count)
 							{
-								Logs.Client.LogError("Tumbler escrow ouptut out-of-bound");
+								Logs.Client.LogError("Tumbler escrow output out-of-bound");
 								Status = PaymentStateMachineStatus.Wasted;
 								break;
 							}

--- a/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
+++ b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
@@ -1,27 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Crypto;
+using NTumbleBit.ClassicTumbler.Server.Models;
+using NTumbleBit.Logging;
 using NTumbleBit.PuzzlePromise;
 using NTumbleBit.PuzzleSolver;
-using NTumbleBit.ClassicTumbler;
-using System.Net;
-using NBitcoin;
 using NTumbleBit.Services;
-using NBitcoin.Crypto;
-using NTumbleBit.Logging;
-using Microsoft.Extensions.Logging;
-using NTumbleBit.ClassicTumbler.Server.Models;
-using System.Text;
+using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 // For more information on enabling Web API for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 
 namespace NTumbleBit.ClassicTumbler.Server.Controllers
 {
-	public class MainController : Controller
+    public class MainController : Controller
 	{
 		public MainController(TumblerRuntime runtime)
 		{
@@ -81,7 +78,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			ClassicTumblerParameters tumblerId)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			return tumblerId;
 		}
 
@@ -91,7 +88,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			ClassicTumblerParameters tumblerId)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var height = Services.BlockExplorerService.GetCurrentHeight();
 			var cycleParameters = Parameters.CycleGenerator.GetRegistratingCycle(height);
 			PuzzleSolution solution = null;
@@ -116,7 +113,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			int cycleStart)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var height = Services.BlockExplorerService.GetCurrentHeight();
 			var cycle = GetCycle(cycleStart);
 			int keyIndex;
@@ -146,7 +143,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[FromBody]SignVoucherRequest request)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			if(request.UnsignedVoucher == null)
 				throw new ActionResultException(BadRequest("Missing UnsignedVoucher"));
 			if(request.MerkleProof == null)
@@ -274,7 +271,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[FromBody] OpenChannelRequest request)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var height = Services.BlockExplorerService.GetCurrentHeight();
 			if(Repository.IsUsed(request.CycleStart, request.Nonce))
 				throw new ActionResultException(BadRequest("duplicate-query"));
@@ -381,7 +378,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[FromBody]SignaturesRequest sigReq)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var session = GetPromiseServerSession(cycleId, channelId, CyclePhase.TumblerChannelEstablishment);
 			AssertNotDuplicateQuery(cycleId, channelId);
 			var hashes = session.SignHashes(sigReq);
@@ -398,7 +395,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[FromBody]PuzzlePromise.ClientRevelation revelation)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var session = GetPromiseServerSession(cycleId, channelId, CyclePhase.TumblerChannelEstablishment);
 			AssertNotDuplicateQuery(cycleId, channelId);
 			var proof = session.CheckRevelation(revelation);
@@ -450,7 +447,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[FromBody]PuzzleValue[] puzzles)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var session = GetSolverServerSession(cycleId, channelId, CyclePhase.PaymentPhase);
 			AssertNotDuplicateQuery(cycleId, channelId);
 
@@ -470,7 +467,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[ModelBinder(BinderType = typeof(UInt160ModelBinder))]  uint160 channelId)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var session = GetSolverServerSession(cycleId, channelId, CyclePhase.PaymentPhase);
 			if(session.Status != SolverServerStates.WaitingCommitmentDelivery)
 				return null;
@@ -504,7 +501,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[FromBody]PuzzleSolver.ClientRevelation revelation)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var session = GetSolverServerSession(cycleId, channelId, CyclePhase.PaymentPhase);
 			AssertNotDuplicateQuery(cycleId, channelId);
 			var solutions = session.CheckRevelation(revelation);
@@ -521,7 +518,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			[FromBody]BlindFactor[] blindFactors)
 		{
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var session = GetSolverServerSession(cycleId, channelId, CyclePhase.PaymentPhase);
 			AssertNotDuplicateQuery(cycleId, channelId);
 			var feeRate = await Services.FeeService.GetFeeRateAsync();
@@ -540,7 +537,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 		{
 			var signature = wrapper?.Signature;
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			if(signature == null)
 				throw new ActionResultException(BadRequest("Missing Signature"));
 			var session = GetSolverServerSession(cycleId, channelId, CyclePhase.TumblerCashoutPhase);
@@ -592,7 +589,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 		{
 			var clientSignature = wrapper?.Signature;
 			if(tumblerId == null)
-				throw new ArgumentNullException("tumblerId");
+				throw new ArgumentNullException(nameof(tumblerId));
 			var session = GetSolverServerSession(cycleId, channelId, CyclePhase.TumblerCashoutPhase);
 			AssertNotDuplicateQuery(cycleId, channelId);
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The current version has an implementation of:
 
 1. TOR integration for Tumbler server and client
 2. Localhost website as user interface for Tumbler server and Tumbler Client.
-3. TumbleBit: Uni-directional Paymen Hub Mode
+3. TumbleBit: Uni-directional Payment Hub Mode
 
 ## Developing on Linux or Mac
 


### PR DESCRIPTION
Just fixed a tiny typo in the README file and changed "tumblerId" to nameof(tumblerId) in two files to keep it consistent with the rest of the code.