### PR TITLE
Fixed a typo in a function name.

### DIFF
--- a/NTumbleBit.Tests/PuzzleProtocolsTests.cs
+++ b/NTumbleBit.Tests/PuzzleProtocolsTests.cs
@@ -141,9 +141,9 @@ namespace NTumbleBit.Tests
 			var cycleGenerator = new OverlappedCycleGenerator();
 			cycleGenerator.FirstCycle = parameter;
 			cycleGenerator.RegistrationOverlap = 3;
-			Assert.Equal(100, cycleGenerator.GetRegistratingCycle(100).Start);
-			Assert.Equal(100, cycleGenerator.GetRegistratingCycle(106).Start);
-			Assert.Equal(107, cycleGenerator.GetRegistratingCycle(107).Start);
+			Assert.Equal(100, cycleGenerator.GetRegisteringCycle(100).Start);
+			Assert.Equal(100, cycleGenerator.GetRegisteringCycle(106).Start);
+			Assert.Equal(107, cycleGenerator.GetRegisteringCycle(107).Start);
 		}
 
 		[Fact]

--- a/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
+++ b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs
@@ -181,7 +181,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 			CyclePhase phase;
 			if(ClientChannelNegotiation == null)
 			{
-				cycle = Parameters.CycleGenerator.GetRegistratingCycle(height);
+				cycle = Parameters.CycleGenerator.GetRegisteringCycle(height);
 				phase = CyclePhase.Registration;
 			}
 			else

--- a/NTumbleBit/ClassicTumbler/Client/StateMachinesExecutor.cs
+++ b/NTumbleBit/ClassicTumbler/Client/StateMachinesExecutor.cs
@@ -49,7 +49,7 @@ namespace NTumbleBit.ClassicTumbler.Client
 						lastBlock = Runtime.Services.BlockExplorerService.WaitBlock(lastBlock, cancellationToken);
 						var height = Runtime.Services.BlockExplorerService.GetCurrentHeight();
 						Logs.Client.LogInformation("New Block: " + height);
-						var cycle = Runtime.TumblerParameters.CycleGenerator.GetRegistratingCycle(height);
+						var cycle = Runtime.TumblerParameters.CycleGenerator.GetRegisteringCycle(height);
 						if(lastCycle != cycle.Start)
 						{
 							lastCycle = cycle.Start;

--- a/NTumbleBit/ClassicTumbler/CycleGenerator.cs
+++ b/NTumbleBit/ClassicTumbler/CycleGenerator.cs
@@ -43,7 +43,7 @@ namespace NTumbleBit.ClassicTumbler
 			}
 		}
 
-		public CycleParameters GetRegistratingCycle(int blockHeight)
+		public CycleParameters GetRegisteringCycle(int blockHeight)
 		{
 			if(blockHeight < FirstCycle.Start)
 				throw new InvalidOperationException("cycle generation starts at " + FirstCycle.Start);
@@ -91,7 +91,7 @@ namespace NTumbleBit.ClassicTumbler
 		public CycleParameters[] GetCycles(int height)
 		{
 			List<CycleParameters> cycles = new List<CycleParameters>();
-			var cycle = GetRegistratingCycle(height);
+			var cycle = GetRegisteringCycle(height);
 			while(cycle.IsInside(height))
 			{
 				var prev = GetPreviousCycle(cycle);

--- a/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
+++ b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
@@ -93,7 +93,7 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
 			if(tumblerId == null)
 				throw new ArgumentNullException(nameof(tumblerId));
 			var height = Services.BlockExplorerService.GetCurrentHeight();
-			var cycleParameters = Parameters.CycleGenerator.GetRegistratingCycle(height);
+			var cycleParameters = Parameters.CycleGenerator.GetRegisteringCycle(height);
 			PuzzleSolution solution = null;
 			var puzzle = Parameters.VoucherKey.PublicKey.GeneratePuzzle(ref solution);
 			uint160 nonce;


### PR DESCRIPTION
Just fixed a typo in function name from "Get**Registrating**Cycle" to "Get**Registering**Cycle"