### PR TITLE
Fix wording

### DIFF
--- a/NTumbleBit/Tor/SocksMessageHandler.cs
+++ b/NTumbleBit/Tor/SocksMessageHandler.cs
@@ -132,7 +132,7 @@ namespace NTumbleBit.Tor
 			catch(TaskCanceledException ex)
 			{
 				SafeDispose(ref s);
-				throw new TaskCanceledException("TOR failed to not connect to the remote server", ex);
+				throw new TaskCanceledException("TOR failed to connect to the remote server", ex);
 			}
 			catch
 			{


### PR DESCRIPTION
Original statement was misinforming user that TOR was failing to "disconnect" from the server by saying "failed to *not* connect", as using *failed* and *not* in the same statement implies a double negative.