### PR TITLE
Updated the proof implementation

### DIFF
--- a/NTumbleBit/Proof/Extensions.cs
+++ b/NTumbleBit/Proof/Extensions.cs
@@ -3,13 +3,7 @@ using NTumbleBit.BouncyCastle.Asn1.Pkcs;
 using NTumbleBit.BouncyCastle.Asn1.X509;
 using NTumbleBit.BouncyCastle.Crypto.Engines;
 using NTumbleBit.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Asn1.Pkcs;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TumbleBitSetup
 {
@@ -23,7 +17,7 @@ namespace TumbleBitSetup
         /// <returns></returns>
         internal static byte[] Decrypt(this RsaPrivateCrtKeyParameters privKey, byte[] encrypted)
         {
-            if(encrypted == null)
+            if (encrypted == null)
                 throw new ArgumentNullException(nameof(encrypted));
 
             RsaEngine engine = new RsaEngine();
@@ -40,7 +34,7 @@ namespace TumbleBitSetup
         /// <returns></returns>
         internal static byte[] Encrypt(this RsaKeyParameters pubKey, byte[] data)
         {
-            if(data == null)
+            if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
             RsaEngine engine = new RsaEngine();

--- a/NTumbleBit/Proof/PermutationTest/PermutationTestSetup.cs
+++ b/NTumbleBit/Proof/PermutationTest/PermutationTestSetup.cs
@@ -9,6 +9,8 @@ namespace TumbleBitSetup
 
         }
 
+        public static readonly int[] SPECIAL_E_VALUES = new int[] { 3, 5, 17, 257, 65537 };
+
         public PermutationTestSetup(byte[] publicString, int alpha, int keySize, int securityParameter = 128)
         {
             if (KeySize < 0)

--- a/NTumbleBit/Proof/PoupardStern/Implementation/PoupardStern.cs
+++ b/NTumbleBit/Proof/PoupardStern/Implementation/PoupardStern.cs
@@ -31,19 +31,13 @@ namespace TumbleBitSetup
             BigInteger Two = BigInteger.Two;
             // 2^{|N| - 1}
             BigInteger lowerLimit = Two.Pow(keyLength - 1);
-            // 2^{|N|}
-            BigInteger upperLimit = Two.Pow(keyLength);
 
             // Rounding up k to the closest multiple of 8
             k = Utils.GetByteLength(k) * 8;
 
-            // Check if N < 2^{|N|-1}
-            if (Modulus.CompareTo(lowerLimit) < 0)
-                throw new ArgumentOutOfRangeException("RSA modulus smaller than expected");
-
-            // if N >= 2^{KeySize}
-            if (Modulus.CompareTo(upperLimit) >= 0)
-                throw new ArgumentOutOfRangeException("RSA modulus larger than expected");
+            // if N < 2^{KeySize-1} or N >= 2^{KeySize}
+            if (Modulus.BitLength != keyLength)
+                throw new ArgumentOutOfRangeException("RSA modulus value is out of range");
 
             // if even
             if ((Modulus.IntValue & 1) == 0)
@@ -129,11 +123,6 @@ namespace TumbleBitSetup
             var y = proof.YValue;
 
             BigInteger rPrime;
-            BigInteger Two = BigInteger.Two;
-            // 2^{|N| - 1}
-            BigInteger lowerLimit = Two.Pow(keyLength - 1);
-            // 2^{|N|}
-            BigInteger upperLimit = Two.Pow(keyLength);
 
             // Rounding up k to the closest multiple of 8
             k = Utils.GetByteLength(k) * 8;
@@ -143,20 +132,19 @@ namespace TumbleBitSetup
 
             // Checking that:
             // if y >= 2^{ |N| - 1 }
-            if (y.CompareTo(lowerLimit) >= 0)
+            if (y.BitLength >= keyLength)
+                // TODO: Verify that this bit check is equivalent to the math check
                 return false;
             // if y < 0
             if (y.CompareTo(BigInteger.Zero) < 0)
                 return false;
-            // if N < 2^{KeySize-1}
-            if (Modulus.CompareTo(lowerLimit) < 0)
+            // if N < 2^{KeySize-1} or N >= 2^{KeySize}
+            if (Modulus.BitLength != keyLength)
                 return false;
             // if even
             if ((Modulus.IntValue & 1) == 0)
                 return false;
-            // if N >= 2^{KeySize}
-            if (Modulus.CompareTo(upperLimit) >= 0)
-                return false;
+
 
             // Computing K
             GetK(k, out int BigK);

--- a/NTumbleBit/Proof/PoupardStern/PoupardSternProof.cs
+++ b/NTumbleBit/Proof/PoupardStern/PoupardSternProof.cs
@@ -7,7 +7,7 @@ namespace TumbleBitSetup
     {
         internal PoupardSternProof(Tuple<BigInteger[], BigInteger> proof)
         {
-            if(proof == null)
+            if (proof == null)
                 throw new ArgumentNullException(nameof(proof));
             XValues = proof.Item1;
             YValue = proof.Item2;


### PR DESCRIPTION
The TumbleBitSetup protocol paper was reviewed and the protocol was modified slightly. This pull request updates the implementation to reflect the fixes/updates to the paper.

Fixes included:
- The way m1 and m2 are generated (changed in the paper).
- The number of m1 iterations was not preformed correctly
  - Originally it was:
 https://github.com/NTumbleBit/NTumbleBit/blob/1f036dac064af240b8b951deada87fde36834c83/NTumbleBit/Proof/PermutationTest/Implementation/PermutationTest.cs#L72-L75
    But this would preform `m+1` iterations since i starts from 0
  So the fix would be to remove the `=` sign on line 74

Changes include performance optimizations such as the way the Modulus value of the RSA key was checked.
Instead of this
https://github.com/NTumbleBit/NTumbleBit/blob/1f036dac064af240b8b951deada87fde36834c83/NTumbleBit/Proof/PermutationTest/Implementation/PermutationTest.cs#L105-L117
We can just do this instead
```csharp          
            // if N < 2^{KeySize-1} or N >= 2^{KeySize}
            if (Modulus.BitLength != keyLength)
                return false;
```
And other small optimizations that could be found in the pull request.

I ran `NTumbleBit.Tests:TestStandard` after the changes and it passed, feel free to try any other tests and check if the updates would break anything.